### PR TITLE
[voyage-context-3] Support contextualized chunk embeddings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ aiolimiter = "*"
 pillow = "*"
 pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
-langchain-text-splitters = ">=0.3.9"
+langchain-text-splitters = ">=0.3.8"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ aiolimiter = "*"
 pillow = "*"
 pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
+langchain-text-splitters = ">=0.3.9"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -153,7 +153,7 @@ class TestClient:
         result = vo.contextualized_embed(
             inputs=[[doc], [doc, doc]], 
             model=self.context_embed_model, 
-            chunk_fn=default_chunk_fn(chunk_size=1, chunk_overlap=0),
+            chunk_fn=default_chunk_fn(chunk_size=1),
         )
         assert len(result.results) == 2
         assert result.total_tokens == len(doc) * 3

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import importlib.metadata
 
 import voyageai
 import voyageai.error as error
-from voyageai.chunking import default_chunking_fn
+from voyageai.chunking import default_chunk_fn
 
 
 class TestClient:
@@ -153,7 +153,7 @@ class TestClient:
         result = vo.contextualized_embed(
             inputs=[[doc], [doc, doc]], 
             model=self.context_embed_model, 
-            chunk_fn=default_chunking_fn(chunk_size=1, chunk_overlap=0),
+            chunk_fn=default_chunk_fn(chunk_size=1, chunk_overlap=0),
         )
         assert len(result.results) == 2
         assert result.total_tokens == len(doc) * 3

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -147,7 +147,7 @@ class TestAsyncClient:
         result = await vo.contextualized_embed(
             inputs=[[doc], [doc, doc]], 
             model=self.context_embed_model, 
-            chunk_fn=default_chunk_fn(chunk_size=1, chunk_overlap=0),
+            chunk_fn=default_chunk_fn(chunk_size=1),
         )
         assert len(result.results) == 2
         assert result.total_tokens == len(doc) * 3

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -1,11 +1,13 @@
 import pytest
 import voyageai
 import voyageai.error as error
+from voyageai.chunking import default_chunking_fn
 
 
 class TestAsyncClient:
 
     embed_model = "voyage-2"
+    context_embed_model = "voyage-context-3"
     rerank_model = "rerank-lite-1"
 
     sample_query = "This is a test query."
@@ -13,6 +15,11 @@ class TestAsyncClient:
         "This is a test document.",
         "This is a test document 1.",
         "This is a test document 2.",
+    ]
+    sample_chunked_query = [[sample_query]]
+    sample_chunked_docs =[
+        ["This is doc 1 chunk 1."],
+        ["This is doc 2 chunk 1.", "This is doc 2 chunk 2."],
     ]
 
     """
@@ -99,6 +106,104 @@ class TestAsyncClient:
         assert len(result.embeddings[0]) == 32
         assert isinstance(result.embeddings[0][0], int)
 
+    """
+    Contextualized embeddings
+    """
+    async def test_async_client_contextualized_embed(self):
+        vo = voyageai.AsyncClient()
+        result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model)
+        assert len(result.results) == 1
+        assert len(result.results[0].embeddings) == 1
+        assert len(result.results[0].embeddings[0]) == 1024
+        assert result.total_tokens > 0
+
+        result = await vo.contextualized_embed(
+            inputs=self.sample_chunked_docs, model=self.context_embed_model)
+        assert len(result.results) == 2
+        assert len(result.results[0].embeddings) == 1
+        assert len(result.results[0].embeddings[0]) == 1024
+        assert len(result.results[1].embeddings) == 2
+        assert len(result.results[1].embeddings[0]) == 1024
+        assert len(result.results[1].embeddings[1]) == 1024
+        assert result.total_tokens > 0
+
+    async def test_async_client_contextualized_embed_input_type(self):
+        vo = voyageai.AsyncClient()
+        query_result = await vo.contextualized_embed(
+            inputs=self.sample_chunked_query, model=self.context_embed_model, input_type="query"
+        )
+        query_embd = query_result.results[0].embeddings[0]
+        doc_result = await vo.contextualized_embed(
+            inputs=self.sample_chunked_docs, model=self.context_embed_model, input_type="document"
+        )
+        doc_embd = doc_result.results[0].embeddings[0]
+        assert len(query_embd) == 1024
+        assert len(doc_embd) == 1024
+        assert query_embd[0] != doc_embd[0]
+
+    async def test_async_client_contextualized_embed_with_chunking_fn(self):
+        vo = voyageai.AsyncClient()
+        doc = "I am an unchunked document"
+        result = await vo.contextualized_embed(
+            inputs=[[doc], [doc, doc]], 
+            model=self.context_embed_model, 
+            chunk_fn=default_chunking_fn(chunk_size=1, chunk_overlap=0),
+        )
+        assert len(result.results) == 2
+        assert result.total_tokens == len(doc) * 3
+        assert result.chunk_texts is not None
+        assert len(result.chunk_texts) == 2
+        assert len(result.chunk_texts[0]) == len(doc)
+        assert len(result.chunk_texts[1]) == len(doc) * 2
+
+    async def test_async_client_contextualized_embed_batch_size(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(voyageai.error.InvalidRequestError):
+            await vo.contextualized_embed(inputs=self.sample_chunked_docs * 1100, model=self.context_embed_model)
+
+    async def test_async_client_contextualized_embed_context_length(self):
+        vo = voyageai.AsyncClient()
+        texts = self.sample_chunked_docs + self.sample_chunked_query * 998
+
+        result = await vo.contextualized_embed(inputs=texts, model=self.context_embed_model)
+        assert result.total_tokens <= 6015
+
+    async def test_async_client_contextualized_embed_invalid_request(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(error.InvalidRequestError):
+            await vo.contextualized_embed(inputs=self.sample_chunked_query, model="wrong-model-name")
+
+    async def test_async_client_contextualized_embed_timeout(self):
+        vo = voyageai.AsyncClient(timeout=1, max_retries=1)
+        with pytest.raises(error.Timeout):
+            await vo.contextualized_embed(inputs=[[self.sample_query] * 100] * 100, model=self.context_embed_model)
+
+    async def test_async_client_contextualized_embed_output_dtype(self):
+        vo = voyageai.AsyncClient()
+        result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model)
+        assert len(result.results) == 1
+        assert len(result.results[0].embeddings) == 1
+        assert len(result.results[0].embeddings[0]) == 1024
+        assert isinstance(result.results[0].embeddings[0][0], float)
+        assert result.total_tokens > 0
+
+        result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model, output_dtype="float", output_dimension=1024)
+        assert len(result.results) == 1
+        assert len(result.results[0].embeddings) == 1
+        assert len(result.results[0].embeddings[0]) == 1024
+        assert isinstance(result.results[0].embeddings[0][0], float)
+
+        result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model, output_dtype="int8", output_dimension=2048)
+        assert len(result.results) == 1
+        assert len(result.results[0].embeddings) == 1
+        assert len(result.results[0].embeddings[0]) == 2048
+        assert isinstance(result.results[0].embeddings[0][0], int)
+
+        result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model, output_dtype="ubinary", output_dimension=256)
+        assert len(result.results) == 1
+        assert len(result.results[0].embeddings) == 1
+        assert len(result.results[0].embeddings[0]) == 32
+        assert isinstance(result.results[0].embeddings[0][0], int)
 
     """
     Reranker
@@ -150,7 +255,7 @@ class TestAsyncClient:
         assert len(result[2].tokens) == 9
 
     def test_async_client_count_tokens(self):
-        vo = voyageai.Client()
+        vo = voyageai.AsyncClient()
         total_tokens = vo.count_tokens([self.sample_query], self.embed_model)
         assert total_tokens == 7
 

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -1,7 +1,7 @@
 import pytest
 import voyageai
 import voyageai.error as error
-from voyageai.chunking import default_chunking_fn
+from voyageai.chunking import default_chunk_fn
 
 
 class TestAsyncClient:
@@ -147,7 +147,7 @@ class TestAsyncClient:
         result = await vo.contextualized_embed(
             inputs=[[doc], [doc, doc]], 
             model=self.context_embed_model, 
-            chunk_fn=default_chunking_fn(chunk_size=1, chunk_overlap=0),
+            chunk_fn=default_chunk_fn(chunk_size=1, chunk_overlap=0),
         )
         assert len(result.results) == 2
         assert result.total_tokens == len(doc) * 3

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -109,6 +109,7 @@ class TestAsyncClient:
     """
     Contextualized embeddings
     """
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed(self):
         vo = voyageai.AsyncClient()
         result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model)
@@ -127,6 +128,7 @@ class TestAsyncClient:
         assert len(result.results[1].embeddings[1]) == 1024
         assert result.total_tokens > 0
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_input_type(self):
         vo = voyageai.AsyncClient()
         query_result = await vo.contextualized_embed(
@@ -141,6 +143,7 @@ class TestAsyncClient:
         assert len(doc_embd) == 1024
         assert query_embd[0] != doc_embd[0]
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_with_chunking_fn(self):
         vo = voyageai.AsyncClient()
         doc = "I am an unchunked document"
@@ -156,11 +159,13 @@ class TestAsyncClient:
         assert len(result.chunk_texts[0]) == len(doc)
         assert len(result.chunk_texts[1]) == len(doc) * 2
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_batch_size(self):
         vo = voyageai.AsyncClient()
         with pytest.raises(voyageai.error.InvalidRequestError):
             await vo.contextualized_embed(inputs=self.sample_chunked_docs * 1100, model=self.context_embed_model)
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_context_length(self):
         vo = voyageai.AsyncClient()
         texts = self.sample_chunked_docs + self.sample_chunked_query * 998
@@ -168,16 +173,19 @@ class TestAsyncClient:
         result = await vo.contextualized_embed(inputs=texts, model=self.context_embed_model)
         assert result.total_tokens <= 6015
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_invalid_request(self):
         vo = voyageai.AsyncClient()
         with pytest.raises(error.InvalidRequestError):
             await vo.contextualized_embed(inputs=self.sample_chunked_query, model="wrong-model-name")
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_timeout(self):
         vo = voyageai.AsyncClient(timeout=1, max_retries=1)
         with pytest.raises(error.Timeout):
             await vo.contextualized_embed(inputs=[[self.sample_query] * 100] * 100, model=self.context_embed_model)
 
+    @pytest.mark.asyncio
     async def test_async_client_contextualized_embed_output_dtype(self):
         vo = voyageai.AsyncClient()
         result = await vo.contextualized_embed(inputs=self.sample_chunked_query, model=self.context_embed_model)

--- a/voyageai/__init__.py
+++ b/voyageai/__init__.py
@@ -19,7 +19,9 @@ if "pkg_resources" not in sys.modules:
 VOYAGE_EMBED_BATCH_SIZE = 128
 VOYAGE_EMBED_DEFAULT_MODEL = "voyage-2"
 
-from voyageai.api_resources import Embedding, Reranking, MultimodalEmbedding
+from voyageai.api_resources import (
+    ContextualizedEmbedding, Embedding, Reranking, MultimodalEmbedding,
+)
 from voyageai.version import VERSION
 from voyageai.client import Client
 from voyageai.client_async import AsyncClient

--- a/voyageai/__init__.py
+++ b/voyageai/__init__.py
@@ -23,6 +23,7 @@ from voyageai.api_resources import (
     ContextualizedEmbedding, Embedding, Reranking, MultimodalEmbedding,
 )
 from voyageai.version import VERSION
+from voyageai.chunking import default_chunk_fn
 from voyageai.client import Client
 from voyageai.client_async import AsyncClient
 from voyageai.embeddings_utils import (

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -4,13 +4,14 @@ import json
 from abc import ABC, abstractmethod
 import functools
 import warnings
-from typing import Any, List, Optional, Union, Dict
+from typing import Any, Callable, List, Optional, Union, Dict
 
 from huggingface_hub import hf_hub_download
 import PIL.Image
 
 import voyageai
 import voyageai.error as error
+from voyageai.object.contextualized_embeddings import ContextualizedEmbeddingsObject
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest, MultimodalInputSegmentText, \
     MultimodalInputSegmentImageURL, MultimodalInputSegmentImageBase64, MultimodalEmbeddingsObject
 from voyageai.util import default_api_key
@@ -67,6 +68,18 @@ class _BaseClient(ABC):
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
     ) -> EmbeddingsObject:
+        pass
+
+    @abstractmethod
+    def contextualized_embed(
+        self,
+        inputs: List[List[str]],
+        model: str,
+        input_type: Optional[str] = None,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+        chunk_fn: Optional[Callable[[str], List[str]]] = None,
+    ) -> ContextualizedEmbeddingsObject:
         pass
 
     @abstractmethod

--- a/voyageai/api_resources/__init__.py
+++ b/voyageai/api_resources/__init__.py
@@ -2,6 +2,7 @@ from voyageai.api_resources.response import VoyageResponse
 from voyageai.api_resources.api_requestor import VoyageHttpResponse
 
 from voyageai.api_resources.api_resource import APIResource
+from voyageai.api_resources.contextualized_embedding import ContextualizedEmbedding
 from voyageai.api_resources.embedding import Embedding
 from voyageai.api_resources.reranking import Reranking
 from voyageai.api_resources.multimodal_embedding import MultimodalEmbedding

--- a/voyageai/api_resources/contextualized_embedding.py
+++ b/voyageai/api_resources/contextualized_embedding.py
@@ -1,0 +1,58 @@
+from voyageai.api_resources import APIResource
+from voyageai.util import decode_base64_embedding
+
+
+class ContextualizedEmbedding(APIResource):
+    OBJECT_NAME = "contextualizedembeddings"
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Creates a new embedding for the provided input and parameters.
+        """
+        user_provided_encoding_format = kwargs.get("encoding_format", None)
+
+        # If encoding format was not explicitly specified, we opaquely use base64 for performance
+        if not user_provided_encoding_format:
+            kwargs["encoding_format"] = "base64"
+
+        response = super().create(*args, **kwargs)
+
+        # If a user specifies base64, we'll just return the encoded string.
+        # This is only for the default case.
+        if not user_provided_encoding_format:
+            for chunked_data in response.data:
+                for chunk_embedding in chunked_data.data:
+                # If an engine isn't using this optimization, don't do anything
+                    if type(chunk_embedding["embedding"]) == str:
+                        chunk_embedding["embedding"] = decode_base64_embedding(
+                            chunk_embedding["embedding"], kwargs.get("output_dtype", None)
+                        )
+
+        return response
+
+    @classmethod
+    async def acreate(cls, *args, **kwargs):
+        """
+        Creates a new embedding for the provided input and parameters.
+        """
+        user_provided_encoding_format = kwargs.get("encoding_format", None)
+
+        # If encoding format was not explicitly specified, we opaquely use base64 for performance
+        if not user_provided_encoding_format:
+            kwargs["encoding_format"] = "base64"
+
+        response = await super().acreate(*args, **kwargs)
+
+        # If a user specifies base64, we'll just return the encoded string.
+        # This is only for the default case.
+        if not user_provided_encoding_format:
+            for chunked_data in response.data:
+                for chunk_embedding in chunked_data.data:
+                # If an engine isn't using this optimization, don't do anything
+                    if type(chunk_embedding["embedding"]) == str:
+                        chunk_embedding["embedding"] = decode_base64_embedding(
+                            chunk_embedding["embedding"], kwargs.get("output_dtype", None)
+                        )
+
+        return response

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -4,8 +4,7 @@ from typing import Callable, List
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 
-DEFAULT_CHUNK_SIZE = 1000
-DEFAULT_CHUNK_OVERLAP = 200
+DEFAULT_CHUNK_SIZE = 2048
 SEPARATORS = [
     "\n\n",
     "\n",
@@ -32,10 +31,7 @@ def apply_chunking(
     ]
 
 
-def default_chunk_fn(
-    chunk_size: int = DEFAULT_CHUNK_SIZE,
-    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
-) -> Callable[[str], List[str]]:
+def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE,) -> Callable[[str], List[str]]:
     """ 
     Simple wrapper for LangChain RecursiveCharacterTextSplitter.
     """
@@ -44,7 +40,7 @@ def default_chunk_fn(
         keep_separator="end",
         strip_whitespace=False,
         chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap,
+        chunk_overlap=0,
     )
     def split(text: str) -> List[str]:
         chunks = splitter.create_documents([text])

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -6,6 +6,19 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 DEFAULT_CHUNK_SIZE = 1000
 DEFAULT_CHUNK_OVERLAP = 200
+SEPARATORS = [
+    "\n\n",
+    "\n",
+    "\uff0e",  # Fullwidth full stop
+    "\u3002",  # Ideographic full stop
+    "\uff0c",  # Fullwidth comma
+    "\u3001",  # Ideographic comma
+    ".",
+    ",",
+    " ",
+    "\u200b",  # Zero-width space
+    "",
+]
 
 def apply_chunking(
     inputs: List[List[str]],
@@ -19,7 +32,7 @@ def apply_chunking(
     ]
 
 
-def default_chunking_fn(
+def default_chunk_fn(
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
 ) -> Callable[[str], List[str]]:
@@ -27,6 +40,9 @@ def default_chunking_fn(
     Simple wrapper for LangChain RecursiveCharacterTextSplitter.
     """
     splitter = RecursiveCharacterTextSplitter(
+        separators=SEPARATORS,
+        keep_separator="end",
+        strip_whitespace=False,
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap,
     )

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -31,7 +31,7 @@ def apply_chunking(
     ]
 
 
-def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE,) -> Callable[[str], List[str]]:
+def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE) -> Callable[[str], List[str]]:
     """ 
     Simple wrapper for LangChain RecursiveCharacterTextSplitter.
     """

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -11,10 +11,15 @@ def apply_chunking(
     inputs: List[List[str]],
     chunk_fn: Callable[[str], List[str]],
 ) -> List[List[str]]:
-    return [list(chain.from_iterable(chunk_fn(i) for i in input)) for input in inputs]
+    """
+    Apply chunk_fn to each string in a nested list of inputs and flatten the results
+    """
+    return [
+        list(chain.from_iterable(chunk_fn(i) for i in input)) for input in inputs
+    ]
 
 
-def default_text_splitter(
+def default_chunking_fn(
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
 ) -> Callable[[str], List[str]]:
@@ -26,6 +31,6 @@ def default_text_splitter(
         chunk_overlap=chunk_overlap,
     )
     def split(text: str) -> List[str]:
-        chunks = splitter.create_chunks([text])
+        chunks = splitter.create_documents([text])
         return [chunk.page_content for chunk in chunks]
     return split

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -1,0 +1,31 @@
+from itertools import chain
+from typing import Callable, List
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+
+DEFAULT_CHUNK_SIZE = 1000
+DEFAULT_CHUNK_OVERLAP = 200
+
+def apply_chunking(
+    inputs: List[List[str]],
+    chunk_fn: Callable[[str], List[str]],
+) -> List[List[str]]:
+    return [list(chain.from_iterable(chunk_fn(i) for i in input)) for input in inputs]
+
+
+def default_text_splitter(
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+) -> Callable[[str], List[str]]:
+    """ 
+    Simple wrapper for LangChain RecursiveCharacterTextSplitter.
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+    def split(text: str) -> List[str]:
+        chunks = splitter.create_chunks([text])
+        return [chunk.page_content for chunk in chunks]
+    return split

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, List, Optional, Union, Dict
+from typing import Any, Callable, List, Optional, Union, Dict
 from tenacity import (
     Retrying,
     stop_after_attempt,
@@ -10,9 +10,12 @@ from PIL.Image import Image
 
 import voyageai
 from voyageai._base import _BaseClient
+from voyageai.chunking import apply_chunking
 import voyageai.error as error
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest
-from voyageai.object import EmbeddingsObject, RerankingObject, MultimodalEmbeddingsObject
+from voyageai.object import (
+    ContextualizedEmbeddingsObject, EmbeddingsObject, RerankingObject, MultimodalEmbeddingsObject
+)
 
 
 class Client(_BaseClient):
@@ -76,6 +79,35 @@ class Client(_BaseClient):
 
         result = EmbeddingsObject(response)
         return result
+
+    def contextualized_embed(
+        self,
+        inputs: List[List[str]],
+        model: str,
+        input_type: Optional[str] = None,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+        chunk_fn: Optional[Callable[[str], List[str]]] = None,
+    ) -> ContextualizedEmbeddingsObject:
+        
+        for attempt in self.retry_controller:
+            with attempt:
+                if chunk_fn:
+                    inputs = apply_chunking(inputs, chunk_fn)
+                response = voyageai.ContextualizedEmbedding.create(
+                    input=inputs,
+                    model=model,
+                    input_type=input_type,
+                    output_dtype=output_dtype,
+                    output_dimension=output_dimension,
+                    **self._params,
+                )
+
+        if chunk_fn:
+            return ContextualizedEmbeddingsObject(
+                response=response, chunk_texts=inputs,
+            )
+        return ContextualizedEmbeddingsObject(response)
 
     def rerank(
         self,

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -95,7 +95,7 @@ class Client(_BaseClient):
                 if chunk_fn:
                     inputs = apply_chunking(inputs, chunk_fn)
                 response = voyageai.ContextualizedEmbedding.create(
-                    input=inputs,
+                    inputs=inputs,
                     model=model,
                     input_type=input_type,
                     output_dtype=output_dtype,

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -94,8 +94,8 @@ class AsyncClient(_BaseClient):
             with attempt:
                 if chunk_fn:
                     inputs = apply_chunking(inputs, chunk_fn)
-                response = await voyageai.ContextualizedEmbedding.create(
-                    input=inputs,
+                response = await voyageai.ContextualizedEmbedding.acreate(
+                    inputs=inputs,
                     model=model,
                     input_type=input_type,
                     output_dtype=output_dtype,

--- a/voyageai/object/__init__.py
+++ b/voyageai/object/__init__.py
@@ -1,3 +1,4 @@
+from voyageai.object.contextualized_embeddings import ContextualizedEmbeddingsObject
 from voyageai.object.embeddings import EmbeddingsObject
 from voyageai.object.reranking import RerankingObject
 from voyageai.object.multimodal_embeddings import MultimodalEmbeddingsObject

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -23,13 +23,9 @@ class ContextualizedEmbeddingsObject:
             self.update(response)
 
     def update(self, response: VoyageResponse):
-        if self.chunk_texts:
-            if len(response.data) != len(self.chunk_texts):
-                raise error.ServerError("The server failed to process the request.")
-            for i, d in enumerate(response.data):
-                embeddings = [embd.embedding for embd in d.data]
-                if len(self.chunk_texts[i]) != len(embeddings):
-                    raise error.ServerError("The server failed to process the request.")
+        for i, d in enumerate(response.data):
+            embeddings = [embd.embedding for embd in d.data]
+            if self.chunk_texts:
                 self.results.append(
                     ContextualizedEmbeddingsResult(
                         index=i,
@@ -37,9 +33,7 @@ class ContextualizedEmbeddingsObject:
                         chunk_texts=self.chunk_texts[i],
                     )
                 )
-        else:
-            for i, d in enumerate(response.data):
-                embeddings = [embd.embedding for embd in d.data]
+            else:
                 self.results.append(
                     ContextualizedEmbeddingsResult(
                         index=i,

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -23,18 +23,27 @@ class ContextualizedEmbeddingsObject:
             self.update(response)
 
     def update(self, response: VoyageResponse):
-        if self.chunk_texts and len(response.data) != len(self.chunk_texts):
-            raise error.ServerError("The server failed to process the request.")
-        for i, d in enumerate(response.data):
-            embeddings = [embd.embedding for embd in d.data]
-            if len(self.chunk_texts[i]) != len(embeddings):
+        if self.chunk_texts:
+            if len(response.data) != len(self.chunk_texts):
                 raise error.ServerError("The server failed to process the request.")
-            self.results.append(
-                ContextualizedEmbeddingsResult(
-                    index=i,
-                    embeddings=embeddings,
-                    chunk_texts=self.chunk_texts[i],
+            for i, d in enumerate(response.data):
+                embeddings = [embd.embedding for embd in d.data]
+                if len(self.chunk_texts[i]) != len(embeddings):
+                    raise error.ServerError("The server failed to process the request.")
+                self.results.append(
+                    ContextualizedEmbeddingsResult(
+                        index=i,
+                        embeddings=embeddings,
+                        chunk_texts=self.chunk_texts[i],
+                    )
                 )
-            )
-            self.embeddings.append(d.embedding)
+        else:
+            for i, d in enumerate(response.data):
+                embeddings = [embd.embedding for embd in d.data]
+                self.results.append(
+                    ContextualizedEmbeddingsResult(
+                        index=i,
+                        embeddings=embeddings,
+                    )
+                )
         self.total_tokens += response.usage.total_tokens

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+from voyageai.api_resources import VoyageResponse
+from voyageai import error
+
+@dataclass
+class ContextualizedEmbeddingsResult:
+    index: int
+    embeddings: Union[List[List[float]], List[List[int]]]
+    chunk_texts: Optional[List[str]] = None
+
+
+class ContextualizedEmbeddingsObject:
+    def __init__(
+        self, 
+        response: Optional[VoyageResponse] = None,
+        chunk_texts: Optional[List[List[str]]] = None,
+    ):
+        self.results: List[ContextualizedEmbeddingsResult] = []
+        self.total_tokens: int = 0
+        self.chunk_texts = chunk_texts
+        if response:
+            self.update(response)
+
+    def update(self, response: VoyageResponse):
+        if self.chunk_texts and len(response.data) != len(self.chunk_texts):
+            raise error.ServerError("The server failed to process the request.")
+        for i, d in enumerate(response.data):
+            embeddings = [embd.embedding for embd in d.data]
+            if len(self.chunk_texts[i]) != len(embeddings):
+                raise error.ServerError("The server failed to process the request.")
+            self.results.append(
+                ContextualizedEmbeddingsResult(
+                    index=i,
+                    embeddings=embeddings,
+                    chunk_texts=self.chunk_texts[i],
+                )
+            )
+            self.embeddings.append(d.embedding)
+        self.total_tokens += response.usage.total_tokens


### PR DESCRIPTION
Add support for contextualized chunk embeddings:
- New `contextualized_embed` function in both client and async client, supporting auto chunking through the `chunk_fn` argument
- New `voyageai.default_chunk_fn` utility, wrapping LangChain RecursiveCharacterTextSplitter