### PR TITLE
[voyage-context-3] Support contextualized chunk embeddings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "voyageai"
-version = "0.3.3"
+version = "0.3.4"
 description = ""
 authors = ["Yujie Qian <yujieq@voyageai.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ aiolimiter = "*"
 pillow = "*"
 pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
+langchain-text-splitters = ">=0.3.8"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/voyageai/__init__.py
+++ b/voyageai/__init__.py
@@ -19,8 +19,11 @@ if "pkg_resources" not in sys.modules:
 VOYAGE_EMBED_BATCH_SIZE = 128
 VOYAGE_EMBED_DEFAULT_MODEL = "voyage-2"
 
-from voyageai.api_resources import Embedding, Reranking, MultimodalEmbedding
+from voyageai.api_resources import (
+    ContextualizedEmbedding, Embedding, Reranking, MultimodalEmbedding,
+)
 from voyageai.version import VERSION
+from voyageai.chunking import default_chunk_fn
 from voyageai.client import Client
 from voyageai.client_async import AsyncClient
 from voyageai.embeddings_utils import (

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -4,13 +4,14 @@ import json
 from abc import ABC, abstractmethod
 import functools
 import warnings
-from typing import Any, List, Optional, Union, Dict
+from typing import Any, Callable, List, Optional, Union, Dict
 
 from huggingface_hub import hf_hub_download
 import PIL.Image
 
 import voyageai
 import voyageai.error as error
+from voyageai.object.contextualized_embeddings import ContextualizedEmbeddingsObject
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest, MultimodalInputSegmentText, \
     MultimodalInputSegmentImageURL, MultimodalInputSegmentImageBase64, MultimodalEmbeddingsObject
 from voyageai.util import default_api_key
@@ -67,6 +68,18 @@ class _BaseClient(ABC):
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
     ) -> EmbeddingsObject:
+        pass
+
+    @abstractmethod
+    def contextualized_embed(
+        self,
+        inputs: List[List[str]],
+        model: str,
+        input_type: Optional[str] = None,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+        chunk_fn: Optional[Callable[[str], List[str]]] = None,
+    ) -> ContextualizedEmbeddingsObject:
         pass
 
     @abstractmethod

--- a/voyageai/api_resources/__init__.py
+++ b/voyageai/api_resources/__init__.py
@@ -2,6 +2,7 @@ from voyageai.api_resources.response import VoyageResponse
 from voyageai.api_resources.api_requestor import VoyageHttpResponse
 
 from voyageai.api_resources.api_resource import APIResource
+from voyageai.api_resources.contextualized_embedding import ContextualizedEmbedding
 from voyageai.api_resources.embedding import Embedding
 from voyageai.api_resources.reranking import Reranking
 from voyageai.api_resources.multimodal_embedding import MultimodalEmbedding

--- a/voyageai/api_resources/contextualized_embedding.py
+++ b/voyageai/api_resources/contextualized_embedding.py
@@ -1,0 +1,58 @@
+from voyageai.api_resources import APIResource
+from voyageai.util import decode_base64_embedding
+
+
+class ContextualizedEmbedding(APIResource):
+    OBJECT_NAME = "contextualizedembeddings"
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Creates a new embedding for the provided input and parameters.
+        """
+        user_provided_encoding_format = kwargs.get("encoding_format", None)
+
+        # If encoding format was not explicitly specified, we opaquely use base64 for performance
+        if not user_provided_encoding_format:
+            kwargs["encoding_format"] = "base64"
+
+        response = super().create(*args, **kwargs)
+
+        # If a user specifies base64, we'll just return the encoded string.
+        # This is only for the default case.
+        if not user_provided_encoding_format:
+            for chunked_data in response.data:
+                for chunk_embedding in chunked_data.data:
+                # If an engine isn't using this optimization, don't do anything
+                    if type(chunk_embedding["embedding"]) == str:
+                        chunk_embedding["embedding"] = decode_base64_embedding(
+                            chunk_embedding["embedding"], kwargs.get("output_dtype", None)
+                        )
+
+        return response
+
+    @classmethod
+    async def acreate(cls, *args, **kwargs):
+        """
+        Creates a new embedding for the provided input and parameters.
+        """
+        user_provided_encoding_format = kwargs.get("encoding_format", None)
+
+        # If encoding format was not explicitly specified, we opaquely use base64 for performance
+        if not user_provided_encoding_format:
+            kwargs["encoding_format"] = "base64"
+
+        response = await super().acreate(*args, **kwargs)
+
+        # If a user specifies base64, we'll just return the encoded string.
+        # This is only for the default case.
+        if not user_provided_encoding_format:
+            for chunked_data in response.data:
+                for chunk_embedding in chunked_data.data:
+                # If an engine isn't using this optimization, don't do anything
+                    if type(chunk_embedding["embedding"]) == str:
+                        chunk_embedding["embedding"] = decode_base64_embedding(
+                            chunk_embedding["embedding"], kwargs.get("output_dtype", None)
+                        )
+
+        return response

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -1,0 +1,48 @@
+from itertools import chain
+from typing import Callable, List
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+
+DEFAULT_CHUNK_SIZE = 2048
+SEPARATORS = [
+    "\n\n",
+    "\n",
+    "\uff0e",  # Fullwidth full stop
+    "\u3002",  # Ideographic full stop
+    "\uff0c",  # Fullwidth comma
+    "\u3001",  # Ideographic comma
+    ".",
+    ",",
+    " ",
+    "\u200b",  # Zero-width space
+    "",
+]
+
+def apply_chunking(
+    inputs: List[List[str]],
+    chunk_fn: Callable[[str], List[str]],
+) -> List[List[str]]:
+    """
+    Apply chunk_fn to each string in a nested list of inputs and flatten the results
+    """
+    return [
+        list(chain.from_iterable(chunk_fn(i) for i in input)) for input in inputs
+    ]
+
+
+def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE) -> Callable[[str], List[str]]:
+    """ 
+    Simple wrapper for LangChain RecursiveCharacterTextSplitter.
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        separators=SEPARATORS,
+        keep_separator="end",
+        strip_whitespace=False,
+        chunk_size=chunk_size,
+        chunk_overlap=0,
+    )
+    def split(text: str) -> List[str]:
+        chunks = splitter.create_documents([text])
+        return [chunk.page_content for chunk in chunks]
+    return split

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union, Dict
+from typing import Callable, List, Optional, Union, Dict
 
 from PIL.Image import Image
 from tenacity import (
@@ -11,10 +11,12 @@ from tenacity import (
 
 import voyageai
 from voyageai._base import _BaseClient
+from voyageai.chunking import apply_chunking
 import voyageai.error as error
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest
-from voyageai.object import EmbeddingsObject, RerankingObject, MultimodalEmbeddingsObject
-
+from voyageai.object import (
+    ContextualizedEmbeddingsObject, EmbeddingsObject, RerankingObject, MultimodalEmbeddingsObject
+)
 
 class AsyncClient(_BaseClient):
     """Voyage AI Async Client
@@ -77,6 +79,35 @@ class AsyncClient(_BaseClient):
 
         result = EmbeddingsObject(response)
         return result
+
+    async def contextualized_embed(
+        self,
+        inputs: List[List[str]],
+        model: str,
+        input_type: Optional[str] = None,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+        chunk_fn: Optional[Callable[[str], List[str]]] = None,
+    ) -> ContextualizedEmbeddingsObject:
+        
+        async for attempt in self.retry_controller:
+            with attempt:
+                if chunk_fn:
+                    inputs = apply_chunking(inputs, chunk_fn)
+                response = await voyageai.ContextualizedEmbedding.acreate(
+                    inputs=inputs,
+                    model=model,
+                    input_type=input_type,
+                    output_dtype=output_dtype,
+                    output_dimension=output_dimension,
+                    **self._params,
+                )
+
+        if chunk_fn:
+            return ContextualizedEmbeddingsObject(
+                response=response, chunk_texts=inputs,
+            )
+        return ContextualizedEmbeddingsObject(response)
 
     async def rerank(
         self,

--- a/voyageai/object/__init__.py
+++ b/voyageai/object/__init__.py
@@ -1,3 +1,4 @@
+from voyageai.object.contextualized_embeddings import ContextualizedEmbeddingsObject
 from voyageai.object.embeddings import EmbeddingsObject
 from voyageai.object.reranking import RerankingObject
 from voyageai.object.multimodal_embeddings import MultimodalEmbeddingsObject

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+from voyageai.api_resources import VoyageResponse
+from voyageai import error
+
+@dataclass
+class ContextualizedEmbeddingsResult:
+    index: int
+    embeddings: Union[List[List[float]], List[List[int]]]
+    chunk_texts: Optional[List[str]] = None
+
+
+class ContextualizedEmbeddingsObject:
+    def __init__(
+        self, 
+        response: Optional[VoyageResponse] = None,
+        chunk_texts: Optional[List[List[str]]] = None,
+    ):
+        self.results: List[ContextualizedEmbeddingsResult] = []
+        self.total_tokens: int = 0
+        self.chunk_texts = chunk_texts
+        if response:
+            self.update(response)
+
+    def update(self, response: VoyageResponse):
+        for i, d in enumerate(response.data):
+            embeddings = [embd.embedding for embd in d.data]
+            if self.chunk_texts:
+                self.results.append(
+                    ContextualizedEmbeddingsResult(
+                        index=i,
+                        embeddings=embeddings,
+                        chunk_texts=self.chunk_texts[i],
+                    )
+                )
+            else:
+                self.results.append(
+                    ContextualizedEmbeddingsResult(
+                        index=i,
+                        embeddings=embeddings,
+                    )
+                )
+        self.total_tokens += response.usage.total_tokens


### PR DESCRIPTION
Add support for contextualized chunk embeddings:
- New `contextualized_embed` function in both client and async client, supporting auto chunking through the `chunk_fn` argument
- New `voyageai.default_chunk_fn` utility, wrapping LangChain RecursiveCharacterTextSplitter