### PR TITLE
Move the import of langchain_text_splitters into chunking.default_chunk_fn

### DIFF
--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -1,8 +1,6 @@
 from itertools import chain
 from typing import Callable, List
 
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-
 
 DEFAULT_CHUNK_SIZE = 2048
 SEPARATORS = [
@@ -35,6 +33,14 @@ def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE) -> Callable[[str], Li
     """ 
     Simple wrapper for LangChain RecursiveCharacterTextSplitter.
     """
+    try:
+        from langchain_text_splitters import RecursiveCharacterTextSplitter
+    except ImportError:
+        raise ImportError(
+            "Please install langchain-text-splitters to use the default chunking function: "
+            "pip install langchain-text-splitters"
+        )
+
     splitter = RecursiveCharacterTextSplitter(
         separators=SEPARATORS,
         keep_separator="end",


### PR DESCRIPTION
# Description
- Prevent VoyageAI from pulling in the LangChain stack at import time by moving the langchain_text_splitters import inside the chunking helper.
- Surface a error message if chunking is used without the optional dependency.
- No changes to functional behavior; just defers the heavy dependency until the chunking utilities are actually called.

# Background
Thank you for your continued support.

I noticed that simply `import voyageai` in my project causes `python -X importtime` to take about 5 seconds.

Upon investigating the cause, I discovered that `langchain_text_splitters`, loaded in the global scope of voyageai/chunking.py, finds and imports heavy dependencies within my project, such as sentence-transformers, torch, transformers, and scipy.

Therefore, I would greatly appreciate it if `langchain_text_splitters` could be deferred. I have submitted this PR accordingly.

Thank you.

# Pytest
The following has been verified to pass.
```
pytest tests/test_client.py -k 'with_chunking_fn'
```