### PR TITLE
Add auto-chunking parameters to contextualized_embed

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,13 @@
 import importlib.metadata
+import re
 from typing import List
+from unittest.mock import patch
 
 import pytest
 import voyageai
 import voyageai.error as error
 from langchain_text_splitters import RecursiveCharacterTextSplitter
+from voyageai.api_resources.response import VoyageResponse
 from voyageai.chunking import default_chunk_fn
 
 
@@ -290,6 +293,222 @@ class TestClient:
         assert len(result.results[0].embeddings) == 1
         assert len(result.results[0].embeddings[0]) == 32
         assert isinstance(result.results[0].embeddings[0][0], int)
+
+    """
+    Auto-chunking validation (no network)
+    """
+
+    def test_auto_chunk_flat_list_requires_flag_or_query(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "List[str] inputs requires enable_auto_chunking=True or input_type='query'"
+            ),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc text"], model=self.context_embed_model
+            )
+
+    def test_auto_chunk_requires_document_input_type(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "enable_auto_chunking=True requires input_type='document'"
+            ),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc text"],
+                model=self.context_embed_model,
+                input_type="query",
+                enable_auto_chunking=True,
+            )
+
+    def test_chunk_size_requires_auto_chunking(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "chunk_size and chunk_overlap require enable_auto_chunking=True"
+            ),
+        ):
+            vo.contextualized_embed(
+                inputs=self.sample_chunked_docs,
+                model=self.context_embed_model,
+                chunk_size=128,
+            )
+
+    def test_chunk_overlap_must_be_less_than_chunk_size(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "chunk_overlap (64) must be less than chunk_size (64)"
+            ),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=64,
+                chunk_overlap=64,
+            )
+
+    def test_chunk_fn_and_auto_chunking_mutually_exclusive(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "chunk_fn cannot be combined with enable_auto_chunking=True"
+            ),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_fn=default_chunk_fn(chunk_size=10),
+            )
+
+    def test_auto_chunking_rejects_pre_chunked_doc(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "inputs[0] has 2 chunks; auto-chunking expects one string per document"
+            ),
+        ):
+            vo.contextualized_embed(
+                inputs=[["chunk1", "chunk2"]],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+            )
+
+    """
+    Auto-chunking happy path (mocked transport)
+    """
+
+    @staticmethod
+    def _build_fake_response(
+        chunk_texts: List[List[str]],
+        chunker_version: str = "1.0.0",
+    ) -> VoyageResponse:
+        return VoyageResponse.construct_from(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "list",
+                        "index": i,
+                        "data": [
+                            {
+                                "object": "embedding",
+                                "index": j,
+                                "embedding": [0.1] * 4,
+                                "text": text,
+                            }
+                            for j, text in enumerate(doc_chunks)
+                        ],
+                    }
+                    for i, doc_chunks in enumerate(chunk_texts)
+                ],
+                "model": "voyage-context-3",
+                "usage": {"total_tokens": 42},
+                "chunker_version": chunker_version,
+            }
+        )
+
+    def test_auto_chunking_forwards_params_and_normalizes_flat_input(self):
+        vo = voyageai.Client()
+        captured: dict = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return self._build_fake_response([["a", "b"], ["c"]])
+
+        with patch(
+            "voyageai.ContextualizedEmbedding.create", side_effect=fake_create
+        ):
+            result = vo.contextualized_embed(
+                inputs=["doc one", "doc two"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=256,
+                chunk_overlap=32,
+            )
+
+        assert captured["inputs"] == [["doc one"], ["doc two"]]
+        assert captured["enable_auto_chunking"] is True
+        assert captured["chunk_size"] == 256
+        assert captured["chunk_overlap"] == 32
+        assert result.chunk_texts == [["a", "b"], ["c"]]
+        assert result.results[0].chunk_texts == ["a", "b"]
+        assert result.chunker_version == "1.0.0"
+
+    def test_auto_chunking_with_list_of_lists_input(self):
+        vo = voyageai.Client()
+        captured: dict = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return self._build_fake_response([["x"]])
+
+        with patch(
+            "voyageai.ContextualizedEmbedding.create", side_effect=fake_create
+        ):
+            result = vo.contextualized_embed(
+                inputs=[["doc one"]],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+            )
+
+        assert captured["inputs"] == [["doc one"]]
+        assert captured["enable_auto_chunking"] is True
+        assert "chunk_size" not in captured
+        assert "chunk_overlap" not in captured
+        assert result.chunker_version == "1.0.0"
+
+    def test_query_flat_list_normalized_without_auto_chunking(self):
+        vo = voyageai.Client()
+        captured: dict = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return VoyageResponse.construct_from(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "object": "list",
+                            "index": 0,
+                            "data": [
+                                {"object": "embedding", "index": 0, "embedding": [0.0] * 4}
+                            ],
+                        }
+                    ],
+                    "model": "voyage-context-3",
+                    "usage": {"total_tokens": 1},
+                }
+            )
+
+        with patch(
+            "voyageai.ContextualizedEmbedding.create", side_effect=fake_create
+        ):
+            result = vo.contextualized_embed(
+                inputs=["hello"],
+                model=self.context_embed_model,
+                input_type="query",
+            )
+
+        assert captured["inputs"] == [["hello"]]
+        assert "enable_auto_chunking" not in captured
+        assert result.chunker_version is None
+        assert result.chunk_texts is None
 
     """
     Reranker

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -337,6 +337,62 @@ class TestClient:
                 chunk_size=128,
             )
 
+    def test_empty_inputs_rejected(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("inputs must not be empty"),
+        ):
+            vo.contextualized_embed(
+                inputs=[],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+            )
+
+    def test_chunk_size_must_be_at_least_one(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("chunk_size must be greater than or equal to 1"),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=0,
+            )
+
+    def test_chunk_overlap_must_be_non_negative(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("chunk_overlap must be greater than or equal to 0"),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=128,
+                chunk_overlap=-1,
+            )
+
+    def test_chunk_overlap_requires_chunk_size(self):
+        vo = voyageai.Client()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("chunk_overlap requires chunk_size"),
+        ):
+            vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_overlap=32,
+            )
+
     def test_chunk_overlap_must_be_less_than_chunk_size(self):
         vo = voyageai.Client()
         with pytest.raises(
@@ -443,6 +499,7 @@ class TestClient:
         assert captured["chunk_overlap"] == 32
         assert result.chunk_texts == [["a", "b"], ["c"]]
         assert result.results[0].chunk_texts == ["a", "b"]
+        assert result.results[1].chunk_texts == ["c"]
         assert result.chunker_version == "1.0.0"
 
     def test_auto_chunking_with_list_of_lists_input(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -304,17 +304,13 @@ class TestClient:
                 "List[str] inputs requires enable_auto_chunking=True or input_type='query'"
             ),
         ):
-            vo.contextualized_embed(
-                inputs=["doc text"], model=self.context_embed_model
-            )
+            vo.contextualized_embed(inputs=["doc text"], model=self.context_embed_model)
 
     def test_auto_chunk_requires_document_input_type(self):
         vo = voyageai.Client()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "enable_auto_chunking=True requires input_type='document'"
-            ),
+            match=re.escape("enable_auto_chunking=True requires input_type='document'"),
         ):
             vo.contextualized_embed(
                 inputs=["doc text"],
@@ -327,9 +323,7 @@ class TestClient:
         vo = voyageai.Client()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "chunk_size and chunk_overlap require enable_auto_chunking=True"
-            ),
+            match=re.escape("chunk_size and chunk_overlap require enable_auto_chunking=True"),
         ):
             vo.contextualized_embed(
                 inputs=self.sample_chunked_docs,
@@ -397,9 +391,7 @@ class TestClient:
         vo = voyageai.Client()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "chunk_overlap (64) must be less than chunk_size (64)"
-            ),
+            match=re.escape("chunk_overlap (64) must be less than chunk_size (64)"),
         ):
             vo.contextualized_embed(
                 inputs=["doc"],
@@ -414,9 +406,7 @@ class TestClient:
         vo = voyageai.Client()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "chunk_fn cannot be combined with enable_auto_chunking=True"
-            ),
+            match=re.escape("chunk_fn cannot be combined with enable_auto_chunking=True"),
         ):
             vo.contextualized_embed(
                 inputs=["doc"],
@@ -481,9 +471,7 @@ class TestClient:
             captured.update(kwargs)
             return self._build_fake_response([["a", "b"], ["c"]])
 
-        with patch(
-            "voyageai.ContextualizedEmbedding.create", side_effect=fake_create
-        ):
+        with patch("voyageai.ContextualizedEmbedding.create", side_effect=fake_create):
             result = vo.contextualized_embed(
                 inputs=["doc one", "doc two"],
                 model=self.context_embed_model,
@@ -510,9 +498,7 @@ class TestClient:
             captured.update(kwargs)
             return self._build_fake_response([["x"]])
 
-        with patch(
-            "voyageai.ContextualizedEmbedding.create", side_effect=fake_create
-        ):
+        with patch("voyageai.ContextualizedEmbedding.create", side_effect=fake_create):
             result = vo.contextualized_embed(
                 inputs=[["doc one"]],
                 model=self.context_embed_model,
@@ -539,9 +525,7 @@ class TestClient:
                         {
                             "object": "list",
                             "index": 0,
-                            "data": [
-                                {"object": "embedding", "index": 0, "embedding": [0.0] * 4}
-                            ],
+                            "data": [{"object": "embedding", "index": 0, "embedding": [0.0] * 4}],
                         }
                     ],
                     "model": "voyage-context-3",
@@ -549,9 +533,7 @@ class TestClient:
                 }
             )
 
-        with patch(
-            "voyageai.ContextualizedEmbedding.create", side_effect=fake_create
-        ):
+        with patch("voyageai.ContextualizedEmbedding.create", side_effect=fake_create):
             result = vo.contextualized_embed(
                 inputs=["hello"],
                 model=self.context_embed_model,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -294,9 +294,7 @@ class TestClient:
         assert len(result.results[0].embeddings[0]) == 32
         assert isinstance(result.results[0].embeddings[0][0], int)
 
-    """
-    Auto-chunking validation (no network)
-    """
+    # ---- Auto-chunking validation (no network) ----
 
     def test_auto_chunk_flat_list_requires_flag_or_query(self):
         vo = voyageai.Client()
@@ -387,9 +385,7 @@ class TestClient:
                 enable_auto_chunking=True,
             )
 
-    """
-    Auto-chunking happy path (mocked transport)
-    """
+    # ---- Auto-chunking happy path (mocked transport) ----
 
     @staticmethod
     def _build_fake_response(

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -1,6 +1,11 @@
+import re
+from typing import List
+from unittest.mock import AsyncMock, patch
+
 import pytest
 import voyageai
 import voyageai.error as error
+from voyageai.api_resources.response import VoyageResponse
 from voyageai.chunking import default_chunk_fn
 
 
@@ -246,6 +251,237 @@ class TestAsyncClient:
         assert len(result.results[0].embeddings) == 1
         assert len(result.results[0].embeddings[0]) == 32
         assert isinstance(result.results[0].embeddings[0][0], int)
+
+    """
+    Auto-chunking validation (no network)
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_auto_chunk_flat_list_requires_flag_or_query(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "List[str] inputs requires enable_auto_chunking=True or input_type='query'"
+            ),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc text"], model=self.context_embed_model
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_auto_chunk_requires_document_input_type(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "enable_auto_chunking=True requires input_type='document'"
+            ),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc text"],
+                model=self.context_embed_model,
+                input_type="query",
+                enable_auto_chunking=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_chunk_size_requires_auto_chunking(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "chunk_size and chunk_overlap require enable_auto_chunking=True"
+            ),
+        ):
+            await vo.contextualized_embed(
+                inputs=self.sample_chunked_docs,
+                model=self.context_embed_model,
+                chunk_size=128,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_chunk_overlap_must_be_less_than_chunk_size(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "chunk_overlap (64) must be less than chunk_size (64)"
+            ),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=64,
+                chunk_overlap=64,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_chunk_fn_and_auto_chunking_mutually_exclusive(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "chunk_fn cannot be combined with enable_auto_chunking=True"
+            ),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_fn=default_chunk_fn(chunk_size=10),
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_auto_chunking_rejects_pre_chunked_doc(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "inputs[0] has 2 chunks; auto-chunking expects one string per document"
+            ),
+        ):
+            await vo.contextualized_embed(
+                inputs=[["chunk1", "chunk2"]],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+            )
+
+    """
+    Auto-chunking happy path (mocked transport)
+    """
+
+    @staticmethod
+    def _build_fake_response(
+        chunk_texts: List[List[str]],
+        chunker_version: str = "1.0.0",
+    ) -> VoyageResponse:
+        return VoyageResponse.construct_from(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "list",
+                        "index": i,
+                        "data": [
+                            {
+                                "object": "embedding",
+                                "index": j,
+                                "embedding": [0.1] * 4,
+                                "text": text,
+                            }
+                            for j, text in enumerate(doc_chunks)
+                        ],
+                    }
+                    for i, doc_chunks in enumerate(chunk_texts)
+                ],
+                "model": "voyage-context-3",
+                "usage": {"total_tokens": 42},
+                "chunker_version": chunker_version,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_auto_chunking_forwards_params_and_normalizes_flat_input(self):
+        vo = voyageai.AsyncClient()
+        captured: dict = {}
+        fake_response = self._build_fake_response([["a", "b"], ["c"]])
+
+        async def fake_acreate(**kwargs):
+            captured.update(kwargs)
+            return fake_response
+
+        with patch(
+            "voyageai.ContextualizedEmbedding.acreate",
+            new=AsyncMock(side_effect=fake_acreate),
+        ):
+            result = await vo.contextualized_embed(
+                inputs=["doc one", "doc two"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=256,
+                chunk_overlap=32,
+            )
+
+        assert captured["inputs"] == [["doc one"], ["doc two"]]
+        assert captured["enable_auto_chunking"] is True
+        assert captured["chunk_size"] == 256
+        assert captured["chunk_overlap"] == 32
+        assert result.chunk_texts == [["a", "b"], ["c"]]
+        assert result.results[0].chunk_texts == ["a", "b"]
+        assert result.chunker_version == "1.0.0"
+
+    @pytest.mark.asyncio
+    async def test_async_auto_chunking_with_list_of_lists_input(self):
+        vo = voyageai.AsyncClient()
+        captured: dict = {}
+        fake_response = self._build_fake_response([["x"]])
+
+        async def fake_acreate(**kwargs):
+            captured.update(kwargs)
+            return fake_response
+
+        with patch(
+            "voyageai.ContextualizedEmbedding.acreate",
+            new=AsyncMock(side_effect=fake_acreate),
+        ):
+            result = await vo.contextualized_embed(
+                inputs=[["doc one"]],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+            )
+
+        assert captured["inputs"] == [["doc one"]]
+        assert captured["enable_auto_chunking"] is True
+        assert "chunk_size" not in captured
+        assert "chunk_overlap" not in captured
+        assert result.chunker_version == "1.0.0"
+
+    @pytest.mark.asyncio
+    async def test_async_query_flat_list_normalized_without_auto_chunking(self):
+        vo = voyageai.AsyncClient()
+        captured: dict = {}
+        fake_response = VoyageResponse.construct_from(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "list",
+                        "index": 0,
+                        "data": [
+                            {"object": "embedding", "index": 0, "embedding": [0.0] * 4}
+                        ],
+                    }
+                ],
+                "model": "voyage-context-3",
+                "usage": {"total_tokens": 1},
+            }
+        )
+
+        async def fake_acreate(**kwargs):
+            captured.update(kwargs)
+            return fake_response
+
+        with patch(
+            "voyageai.ContextualizedEmbedding.acreate",
+            new=AsyncMock(side_effect=fake_acreate),
+        ):
+            result = await vo.contextualized_embed(
+                inputs=["hello"],
+                model=self.context_embed_model,
+                input_type="query",
+            )
+
+        assert captured["inputs"] == [["hello"]]
+        assert "enable_auto_chunking" not in captured
+        assert result.chunker_version is None
+        assert result.chunk_texts is None
 
     """
     Reranker

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -299,6 +299,66 @@ class TestAsyncClient:
             )
 
     @pytest.mark.asyncio
+    async def test_async_empty_inputs_rejected(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("inputs must not be empty"),
+        ):
+            await vo.contextualized_embed(
+                inputs=[],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_chunk_size_must_be_at_least_one(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("chunk_size must be greater than or equal to 1"),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_chunk_overlap_must_be_non_negative(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("chunk_overlap must be greater than or equal to 0"),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_size=128,
+                chunk_overlap=-1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_chunk_overlap_requires_chunk_size(self):
+        vo = voyageai.AsyncClient()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("chunk_overlap requires chunk_size"),
+        ):
+            await vo.contextualized_embed(
+                inputs=["doc"],
+                model=self.context_embed_model,
+                input_type="document",
+                enable_auto_chunking=True,
+                chunk_overlap=32,
+            )
+
+    @pytest.mark.asyncio
     async def test_async_chunk_overlap_must_be_less_than_chunk_size(self):
         vo = voyageai.AsyncClient()
         with pytest.raises(
@@ -410,6 +470,7 @@ class TestAsyncClient:
         assert captured["chunk_overlap"] == 32
         assert result.chunk_texts == [["a", "b"], ["c"]]
         assert result.results[0].chunk_texts == ["a", "b"]
+        assert result.results[1].chunk_texts == ["c"]
         assert result.chunker_version == "1.0.0"
 
     @pytest.mark.asyncio

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -263,18 +263,14 @@ class TestAsyncClient:
                 "List[str] inputs requires enable_auto_chunking=True or input_type='query'"
             ),
         ):
-            await vo.contextualized_embed(
-                inputs=["doc text"], model=self.context_embed_model
-            )
+            await vo.contextualized_embed(inputs=["doc text"], model=self.context_embed_model)
 
     @pytest.mark.asyncio
     async def test_async_auto_chunk_requires_document_input_type(self):
         vo = voyageai.AsyncClient()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "enable_auto_chunking=True requires input_type='document'"
-            ),
+            match=re.escape("enable_auto_chunking=True requires input_type='document'"),
         ):
             await vo.contextualized_embed(
                 inputs=["doc text"],
@@ -288,9 +284,7 @@ class TestAsyncClient:
         vo = voyageai.AsyncClient()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "chunk_size and chunk_overlap require enable_auto_chunking=True"
-            ),
+            match=re.escape("chunk_size and chunk_overlap require enable_auto_chunking=True"),
         ):
             await vo.contextualized_embed(
                 inputs=self.sample_chunked_docs,
@@ -363,9 +357,7 @@ class TestAsyncClient:
         vo = voyageai.AsyncClient()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "chunk_overlap (64) must be less than chunk_size (64)"
-            ),
+            match=re.escape("chunk_overlap (64) must be less than chunk_size (64)"),
         ):
             await vo.contextualized_embed(
                 inputs=["doc"],
@@ -381,9 +373,7 @@ class TestAsyncClient:
         vo = voyageai.AsyncClient()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                "chunk_fn cannot be combined with enable_auto_chunking=True"
-            ),
+            match=re.escape("chunk_fn cannot be combined with enable_auto_chunking=True"),
         ):
             await vo.contextualized_embed(
                 inputs=["doc"],
@@ -511,9 +501,7 @@ class TestAsyncClient:
                     {
                         "object": "list",
                         "index": 0,
-                        "data": [
-                            {"object": "embedding", "index": 0, "embedding": [0.0] * 4}
-                        ],
+                        "data": [{"object": "embedding", "index": 0, "embedding": [0.0] * 4}],
                     }
                 ],
                 "model": "voyage-context-3",

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -252,9 +252,7 @@ class TestAsyncClient:
         assert len(result.results[0].embeddings[0]) == 32
         assert isinstance(result.results[0].embeddings[0][0], int)
 
-    """
-    Auto-chunking validation (no network)
-    """
+    # ---- Auto-chunking validation (no network) ----
 
     @pytest.mark.asyncio
     async def test_async_auto_chunk_flat_list_requires_flag_or_query(self):
@@ -351,9 +349,7 @@ class TestAsyncClient:
                 enable_auto_chunking=True,
             )
 
-    """
-    Auto-chunking happy path (mocked transport)
-    """
+    # ---- Auto-chunking happy path (mocked transport) ----
 
     @staticmethod
     def _build_fake_response(

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -84,12 +84,15 @@ class _BaseClient(ABC):
     @abstractmethod
     def contextualized_embed(
         self,
-        inputs: List[List[str]],
+        inputs: Union[List[List[str]], List[str]],
         model: str,
         input_type: Optional[str] = None,
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
         chunk_fn: Optional[Callable[[str], List[str]]] = None,
+        enable_auto_chunking: bool = False,
+        chunk_size: Optional[int] = None,
+        chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
         pass
 

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -40,22 +40,12 @@ def validate_and_normalize_contextualized_inputs(
     """Validate contextualized-embedding params, normalize flat inputs, and
     build the auto-chunking kwargs to forward to the API."""
     if chunk_fn is not None and enable_auto_chunking:
-        raise ValueError(
-            "chunk_fn cannot be combined with enable_auto_chunking=True"
-        )
+        raise ValueError("chunk_fn cannot be combined with enable_auto_chunking=True")
 
-    if not enable_auto_chunking and (
-        chunk_size is not None or chunk_overlap is not None
-    ):
-        raise ValueError(
-            "chunk_size and chunk_overlap require enable_auto_chunking=True"
-        )
+    if not enable_auto_chunking and (chunk_size is not None or chunk_overlap is not None):
+        raise ValueError("chunk_size and chunk_overlap require enable_auto_chunking=True")
 
-    if (
-        chunk_size is not None
-        and chunk_overlap is not None
-        and chunk_overlap >= chunk_size
-    ):
+    if chunk_size is not None and chunk_overlap is not None and chunk_overlap >= chunk_size:
         raise ValueError(
             f"chunk_overlap ({chunk_overlap}) must be less than chunk_size ({chunk_size})"
         )
@@ -78,9 +68,7 @@ def validate_and_normalize_contextualized_inputs(
 
     if enable_auto_chunking:
         if input_type != "document":
-            raise ValueError(
-                "enable_auto_chunking=True requires input_type='document'"
-            )
+            raise ValueError("enable_auto_chunking=True requires input_type='document'")
         for i, doc in enumerate(inputs):
             if len(doc) != 1:
                 raise ValueError(

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
@@ -36,12 +36,9 @@ def validate_and_normalize_contextualized_inputs(
     enable_auto_chunking: bool,
     chunk_size: Optional[int],
     chunk_overlap: Optional[int],
-) -> List[List[str]]:
-    """Validate contextualized-embedding params and normalize flat inputs.
-
-    Mirrors server-side validation in voyageai-backend
-    common/core/api/api_gateway.py so users see consistent error messages.
-    """
+) -> Tuple[List[List[str]], Dict[str, Any]]:
+    """Validate contextualized-embedding params, normalize flat inputs, and
+    build the auto-chunking kwargs to forward to the API."""
     if chunk_fn is not None and enable_auto_chunking:
         raise ValueError(
             "chunk_fn cannot be combined with enable_auto_chunking=True"
@@ -68,14 +65,11 @@ def validate_and_normalize_contextualized_inputs(
         raise ValueError("chunk_overlap must be greater than or equal to 0")
 
     if isinstance(inputs, list) and all(isinstance(s, str) for s in inputs):
-        if input_type == "query":
-            inputs = [[s] for s in inputs]
-        elif enable_auto_chunking:
-            inputs = [[s] for s in inputs]
-        else:
+        if input_type != "query" and not enable_auto_chunking:
             raise ValueError(
                 "List[str] inputs requires enable_auto_chunking=True or input_type='query'"
             )
+        inputs = [[s] for s in inputs]
 
     if enable_auto_chunking:
         if input_type != "document":
@@ -88,7 +82,15 @@ def validate_and_normalize_contextualized_inputs(
                     f"inputs[{i}] has {len(doc)} chunks; auto-chunking expects one string per document"
                 )
 
-    return inputs
+    extra_kwargs: Dict[str, Any] = {}
+    if enable_auto_chunking:
+        extra_kwargs["enable_auto_chunking"] = True
+    if chunk_size is not None:
+        extra_kwargs["chunk_size"] = chunk_size
+    if chunk_overlap is not None:
+        extra_kwargs["chunk_overlap"] = chunk_overlap
+
+    return inputs, extra_kwargs
 
 
 def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE) -> Callable[[str], List[str]]:

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -63,6 +63,11 @@ def validate_and_normalize_contextualized_inputs(
         raise ValueError("chunk_size must be greater than or equal to 1")
     if chunk_overlap is not None and chunk_overlap < 0:
         raise ValueError("chunk_overlap must be greater than or equal to 0")
+    if chunk_overlap is not None and chunk_size is None:
+        raise ValueError("chunk_overlap requires chunk_size")
+
+    if not inputs:
+        raise ValueError("inputs must not be empty")
 
     if isinstance(inputs, list) and all(isinstance(s, str) for s in inputs):
         if input_type != "query" and not enable_auto_chunking:

--- a/voyageai/chunking.py
+++ b/voyageai/chunking.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Callable, List
+from typing import Callable, List, Optional, Union
 
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
@@ -27,6 +27,68 @@ def apply_chunking(
     Apply chunk_fn to each string in a nested list of inputs and flatten the results
     """
     return [list(chain.from_iterable(chunk_fn(i) for i in input)) for input in inputs]
+
+
+def validate_and_normalize_contextualized_inputs(
+    inputs: Union[List[List[str]], List[str]],
+    input_type: Optional[str],
+    chunk_fn: Optional[Callable[[str], List[str]]],
+    enable_auto_chunking: bool,
+    chunk_size: Optional[int],
+    chunk_overlap: Optional[int],
+) -> List[List[str]]:
+    """Validate contextualized-embedding params and normalize flat inputs.
+
+    Mirrors server-side validation in voyageai-backend
+    common/core/api/api_gateway.py so users see consistent error messages.
+    """
+    if chunk_fn is not None and enable_auto_chunking:
+        raise ValueError(
+            "chunk_fn cannot be combined with enable_auto_chunking=True"
+        )
+
+    if not enable_auto_chunking and (
+        chunk_size is not None or chunk_overlap is not None
+    ):
+        raise ValueError(
+            "chunk_size and chunk_overlap require enable_auto_chunking=True"
+        )
+
+    if (
+        chunk_size is not None
+        and chunk_overlap is not None
+        and chunk_overlap >= chunk_size
+    ):
+        raise ValueError(
+            f"chunk_overlap ({chunk_overlap}) must be less than chunk_size ({chunk_size})"
+        )
+    if chunk_size is not None and chunk_size < 1:
+        raise ValueError("chunk_size must be greater than or equal to 1")
+    if chunk_overlap is not None and chunk_overlap < 0:
+        raise ValueError("chunk_overlap must be greater than or equal to 0")
+
+    if isinstance(inputs, list) and all(isinstance(s, str) for s in inputs):
+        if input_type == "query":
+            inputs = [[s] for s in inputs]
+        elif enable_auto_chunking:
+            inputs = [[s] for s in inputs]
+        else:
+            raise ValueError(
+                "List[str] inputs requires enable_auto_chunking=True or input_type='query'"
+            )
+
+    if enable_auto_chunking:
+        if input_type != "document":
+            raise ValueError(
+                "enable_auto_chunking=True requires input_type='document'"
+            )
+        for i, doc in enumerate(inputs):
+            if len(doc) != 1:
+                raise ValueError(
+                    f"inputs[{i}] has {len(doc)} chunks; auto-chunking expects one string per document"
+                )
+
+    return inputs
 
 
 def default_chunk_fn(chunk_size: int = DEFAULT_CHUNK_SIZE) -> Callable[[str], List[str]]:

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -12,7 +12,10 @@ from tenacity import (
 import voyageai
 import voyageai.error as error
 from voyageai._base import _BaseClient
-from voyageai.chunking import apply_chunking
+from voyageai.chunking import (
+    apply_chunking,
+    validate_and_normalize_contextualized_inputs,
+)
 from voyageai.object import (
     ContextualizedEmbeddingsObject,
     EmbeddingsObject,
@@ -93,24 +96,46 @@ class Client(_BaseClient):
 
     def contextualized_embed(
         self,
-        inputs: List[List[str]],
+        inputs: Union[List[List[str]], List[str]],
         model: str,
         input_type: Optional[str] = None,
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
         chunk_fn: Optional[Callable[[str], List[str]]] = None,
+        enable_auto_chunking: bool = False,
+        chunk_size: Optional[int] = None,
+        chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
+        normalized_inputs = validate_and_normalize_contextualized_inputs(
+            inputs=inputs,
+            input_type=input_type,
+            chunk_fn=chunk_fn,
+            enable_auto_chunking=enable_auto_chunking,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+        )
+
+        extra_kwargs: Dict[str, object] = {}
+        if enable_auto_chunking:
+            extra_kwargs["enable_auto_chunking"] = True
+        if chunk_size is not None:
+            extra_kwargs["chunk_size"] = chunk_size
+        if chunk_overlap is not None:
+            extra_kwargs["chunk_overlap"] = chunk_overlap
+
         response = None
         for attempt in self._make_retry_controller():
             with attempt:
+                request_inputs = normalized_inputs
                 if chunk_fn:
-                    inputs = apply_chunking(inputs, chunk_fn)
+                    request_inputs = apply_chunking(normalized_inputs, chunk_fn)
                 response = voyageai.ContextualizedEmbedding.create(
-                    inputs=inputs,
+                    inputs=request_inputs,
                     model=model,
                     input_type=input_type,
                     output_dtype=output_dtype,
                     output_dimension=output_dimension,
+                    **extra_kwargs,
                     **self._params,
                 )
 
@@ -120,7 +145,7 @@ class Client(_BaseClient):
         if chunk_fn:
             return ContextualizedEmbeddingsObject(
                 response=response,
-                chunk_texts=inputs,
+                chunk_texts=request_inputs,
             )
         return ContextualizedEmbeddingsObject(response)
 

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -115,12 +115,13 @@ class Client(_BaseClient):
             chunk_overlap=chunk_overlap,
         )
 
+        request_inputs = (
+            apply_chunking(normalized_inputs, chunk_fn) if chunk_fn else normalized_inputs
+        )
+
         response = None
         for attempt in self._make_retry_controller():
             with attempt:
-                request_inputs = normalized_inputs
-                if chunk_fn:
-                    request_inputs = apply_chunking(normalized_inputs, chunk_fn)
                 response = voyageai.ContextualizedEmbedding.create(
                     inputs=request_inputs,
                     model=model,

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -106,7 +106,7 @@ class Client(_BaseClient):
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
-        normalized_inputs = validate_and_normalize_contextualized_inputs(
+        normalized_inputs, extra_kwargs = validate_and_normalize_contextualized_inputs(
             inputs=inputs,
             input_type=input_type,
             chunk_fn=chunk_fn,
@@ -114,14 +114,6 @@ class Client(_BaseClient):
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
         )
-
-        extra_kwargs: Dict[str, object] = {}
-        if enable_auto_chunking:
-            extra_kwargs["enable_auto_chunking"] = True
-        if chunk_size is not None:
-            extra_kwargs["chunk_size"] = chunk_size
-        if chunk_overlap is not None:
-            extra_kwargs["chunk_overlap"] = chunk_overlap
 
         response = None
         for attempt in self._make_retry_controller():

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -115,12 +115,13 @@ class AsyncClient(_BaseClient):
             chunk_overlap=chunk_overlap,
         )
 
+        request_inputs = (
+            apply_chunking(normalized_inputs, chunk_fn) if chunk_fn else normalized_inputs
+        )
+
         response = None
         async for attempt in self._make_retry_controller():
             with attempt:
-                request_inputs = normalized_inputs
-                if chunk_fn:
-                    request_inputs = apply_chunking(normalized_inputs, chunk_fn)
                 response = await voyageai.ContextualizedEmbedding.acreate(
                     inputs=request_inputs,
                     model=model,

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -12,7 +12,10 @@ from tenacity import (
 import voyageai
 import voyageai.error as error
 from voyageai._base import _BaseClient
-from voyageai.chunking import apply_chunking
+from voyageai.chunking import (
+    apply_chunking,
+    validate_and_normalize_contextualized_inputs,
+)
 from voyageai.object import (
     ContextualizedEmbeddingsObject,
     EmbeddingsObject,
@@ -93,24 +96,46 @@ class AsyncClient(_BaseClient):
 
     async def contextualized_embed(
         self,
-        inputs: List[List[str]],
+        inputs: Union[List[List[str]], List[str]],
         model: str,
         input_type: Optional[str] = None,
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
         chunk_fn: Optional[Callable[[str], List[str]]] = None,
+        enable_auto_chunking: bool = False,
+        chunk_size: Optional[int] = None,
+        chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
+        normalized_inputs = validate_and_normalize_contextualized_inputs(
+            inputs=inputs,
+            input_type=input_type,
+            chunk_fn=chunk_fn,
+            enable_auto_chunking=enable_auto_chunking,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+        )
+
+        extra_kwargs: Dict[str, object] = {}
+        if enable_auto_chunking:
+            extra_kwargs["enable_auto_chunking"] = True
+        if chunk_size is not None:
+            extra_kwargs["chunk_size"] = chunk_size
+        if chunk_overlap is not None:
+            extra_kwargs["chunk_overlap"] = chunk_overlap
+
         response = None
         async for attempt in self._make_retry_controller():
             with attempt:
+                request_inputs = normalized_inputs
                 if chunk_fn:
-                    inputs = apply_chunking(inputs, chunk_fn)
+                    request_inputs = apply_chunking(normalized_inputs, chunk_fn)
                 response = await voyageai.ContextualizedEmbedding.acreate(
-                    inputs=inputs,
+                    inputs=request_inputs,
                     model=model,
                     input_type=input_type,
                     output_dtype=output_dtype,
                     output_dimension=output_dimension,
+                    **extra_kwargs,
                     **self._params,
                 )
 
@@ -120,7 +145,7 @@ class AsyncClient(_BaseClient):
         if chunk_fn:
             return ContextualizedEmbeddingsObject(
                 response=response,
-                chunk_texts=inputs,
+                chunk_texts=request_inputs,
             )
         return ContextualizedEmbeddingsObject(response)
 

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -106,7 +106,7 @@ class AsyncClient(_BaseClient):
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
-        normalized_inputs = validate_and_normalize_contextualized_inputs(
+        normalized_inputs, extra_kwargs = validate_and_normalize_contextualized_inputs(
             inputs=inputs,
             input_type=input_type,
             chunk_fn=chunk_fn,
@@ -114,14 +114,6 @@ class AsyncClient(_BaseClient):
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
         )
-
-        extra_kwargs: Dict[str, object] = {}
-        if enable_auto_chunking:
-            extra_kwargs["enable_auto_chunking"] = True
-        if chunk_size is not None:
-            extra_kwargs["chunk_size"] = chunk_size
-        if chunk_overlap is not None:
-            extra_kwargs["chunk_overlap"] = chunk_overlap
 
         response = None
         async for attempt in self._make_retry_controller():

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Union
 
 from voyageai.api_resources import VoyageResponse
+from voyageai.error import ServerError
 
 
 @dataclass
@@ -39,7 +40,7 @@ class ContextualizedEmbeddingsObject:
                     server_texts_per_doc.append(per_doc_texts)
                     result_chunk_texts = per_doc_texts
                 elif any(t is not None for t in per_doc_texts):
-                    raise ValueError(
+                    raise ServerError(
                         f"inputs[{i}] returned a partial set of chunk texts; "
                         "expected text on every chunk or none"
                     )
@@ -58,7 +59,7 @@ class ContextualizedEmbeddingsObject:
         if client_chunk_texts is None and server_texts_per_doc:
             populated = [t for t in server_texts_per_doc if t is not None]
             if populated and len(populated) != len(server_texts_per_doc):
-                raise ValueError(
+                raise ServerError(
                     "response returned chunk texts for some documents but not others; "
                     "expected all-or-nothing"
                 )

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -20,25 +20,43 @@ class ContextualizedEmbeddingsObject:
         self.results: List[ContextualizedEmbeddingsResult] = []
         self.total_tokens: int = 0
         self.chunk_texts = chunk_texts
+        self.chunker_version: Optional[str] = None
         if response:
             self.update(response)
 
     def update(self, response: VoyageResponse):
+        client_chunk_texts = self.chunk_texts
+        server_chunk_texts: List[List[str]] = []
         for i, d in enumerate(response.data):
             embeddings = [embd.embedding for embd in d.data]
-            if self.chunk_texts:
-                self.results.append(
-                    ContextualizedEmbeddingsResult(
-                        index=i,
-                        embeddings=embeddings,
-                        chunk_texts=self.chunk_texts[i],
-                    )
-                )
+            per_doc_server_texts = [
+                getattr(embd, "text", None) for embd in d.data
+            ]
+            if any(t is not None for t in per_doc_server_texts):
+                server_chunk_texts.append(per_doc_server_texts)
             else:
-                self.results.append(
-                    ContextualizedEmbeddingsResult(
-                        index=i,
-                        embeddings=embeddings,
-                    )
+                server_chunk_texts.append([])
+
+            if client_chunk_texts:
+                result_chunk_texts = client_chunk_texts[i]
+            elif server_chunk_texts[i]:
+                result_chunk_texts = server_chunk_texts[i]
+            else:
+                result_chunk_texts = None
+
+            self.results.append(
+                ContextualizedEmbeddingsResult(
+                    index=i,
+                    embeddings=embeddings,
+                    chunk_texts=result_chunk_texts,
                 )
+            )
+
+        if (
+            client_chunk_texts is None
+            and any(texts for texts in server_chunk_texts)
+        ):
+            self.chunk_texts = server_chunk_texts
+
         self.total_tokens += response.usage.total_tokens
+        self.chunker_version = getattr(response, "chunker_version", None)

--- a/voyageai/object/contextualized_embeddings.py
+++ b/voyageai/object/contextualized_embeddings.py
@@ -26,23 +26,26 @@ class ContextualizedEmbeddingsObject:
 
     def update(self, response: VoyageResponse):
         client_chunk_texts = self.chunk_texts
-        server_chunk_texts: List[List[str]] = []
+        server_texts_per_doc: List[Optional[List[str]]] = []
+
         for i, d in enumerate(response.data):
             embeddings = [embd.embedding for embd in d.data]
-            per_doc_server_texts = [
-                getattr(embd, "text", None) for embd in d.data
-            ]
-            if any(t is not None for t in per_doc_server_texts):
-                server_chunk_texts.append(per_doc_server_texts)
-            else:
-                server_chunk_texts.append([])
 
-            if client_chunk_texts:
+            if client_chunk_texts is not None:
                 result_chunk_texts = client_chunk_texts[i]
-            elif server_chunk_texts[i]:
-                result_chunk_texts = server_chunk_texts[i]
             else:
-                result_chunk_texts = None
+                per_doc_texts = [embd.get("text") for embd in d.data]
+                if all(t is not None for t in per_doc_texts):
+                    server_texts_per_doc.append(per_doc_texts)
+                    result_chunk_texts = per_doc_texts
+                elif any(t is not None for t in per_doc_texts):
+                    raise ValueError(
+                        f"inputs[{i}] returned a partial set of chunk texts; "
+                        "expected text on every chunk or none"
+                    )
+                else:
+                    server_texts_per_doc.append(None)
+                    result_chunk_texts = None
 
             self.results.append(
                 ContextualizedEmbeddingsResult(
@@ -52,11 +55,15 @@ class ContextualizedEmbeddingsObject:
                 )
             )
 
-        if (
-            client_chunk_texts is None
-            and any(texts for texts in server_chunk_texts)
-        ):
-            self.chunk_texts = server_chunk_texts
+        if client_chunk_texts is None and server_texts_per_doc:
+            populated = [t for t in server_texts_per_doc if t is not None]
+            if populated and len(populated) != len(server_texts_per_doc):
+                raise ValueError(
+                    "response returned chunk texts for some documents but not others; "
+                    "expected all-or-nothing"
+                )
+            if populated:
+                self.chunk_texts = populated
 
         self.total_tokens += response.usage.total_tokens
-        self.chunker_version = getattr(response, "chunker_version", None)
+        self.chunker_version = response.get("chunker_version")


### PR DESCRIPTION
## Summary
- Add `enable_auto_chunking`, `chunk_size`, `chunk_overlap` to `Client.contextualized_embed` and `AsyncClient.contextualized_embed`, forwarded to `/contextualizedembeddings` for server-side chunking.
- Widen `inputs` to `Union[List[List[str]], List[str]]` and normalize flat input for `input_type="query"` or auto-chunking; otherwise raise the same error the gateway returns.
- Parse `chunker_version` and per-chunk `text` from the response; surface them on `ContextualizedEmbeddingsObject`.
- Existing `chunk_fn` clients are unaffected (no warnings, same behavior); `chunk_fn` is mutually exclusive with `enable_auto_chunking=True`.

Server-side validation lives at `voyageai-backend/src/python/common/core/api/api_gateway.py:259-321`; the client-side helper in `voyageai/chunking.py` mirrors those rules so users see consistent errors.

Design reference: voyage-context-4 launch eng plan, P1.6 SDK updates.

## Test plan
- [x] `pytest tests/test_client.py tests/test_client_async.py -k "auto_chunk or chunk_overlap or chunk_size_requires or chunk_fn_and_auto or query_flat or auto_chunking" -v` (18 pass — 9 sync + 9 async)
- [x] Full collection still works: `pytest tests/test_client.py tests/test_client_async.py --collect-only` (59 tests)
- [x] Manual smoke against staging once the gateway `enable_auto_chunking` feature flag is on:
  ```python
  vo = voyageai.Client()
  r = vo.contextualized_embed(
      inputs=["Long doc text..."],
      model="voyage-context-3",
      input_type="document",
      enable_auto_chunking=True,
      chunk_size=512,
      chunk_overlap=64,
  )
  assert r.chunker_version is not None
  assert r.chunk_texts and r.chunk_texts[0]
  ```
- [ ] Confirm legacy `chunk_fn` path still works end-to-end against staging.
