### PR TITLE
Fix async cancellation leaking aiohttp ClientSession

### DIFF
--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -1,6 +1,10 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
 import pytest
 import voyageai
 import voyageai.error as error
+from voyageai.api_resources.api_requestor import APIRequestor, AioHTTPSession
 from voyageai.chunking import default_chunk_fn
 
 
@@ -299,3 +303,69 @@ class TestAsyncClient:
 
         total_tokens = vo.count_tokens(self.sample_docs, self.embed_model)
         assert total_tokens == 25
+
+
+class TestAsyncCancellationCleanup:
+    """Verify that asyncio.CancelledError does not leak an aiohttp.ClientSession."""
+
+    @pytest.mark.asyncio
+    async def test_arequest_cleans_up_session_on_cancellation(self):
+        requestor = APIRequestor(key="dummy")
+
+        mock_exit = AsyncMock()
+        original_aenter = AioHTTPSession.__aenter__
+
+        async def patched_aenter(self_session):
+            session = await original_aenter(self_session)
+            return session
+
+        async def slow_arequest_raw(*args, **kwargs):
+            await asyncio.sleep(3600)
+
+        with patch.object(requestor, "arequest_raw", side_effect=slow_arequest_raw), \
+             patch.object(AioHTTPSession, "__aexit__", mock_exit):
+            task = asyncio.create_task(
+                requestor.arequest("POST", "/test", params={})
+            )
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        mock_exit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_arequest_cleans_up_session_on_exception(self):
+        requestor = APIRequestor(key="dummy")
+
+        mock_exit = AsyncMock()
+
+        async def failing_arequest_raw(*args, **kwargs):
+            raise ValueError("boom")
+
+        with patch.object(requestor, "arequest_raw", side_effect=failing_arequest_raw), \
+             patch.object(AioHTTPSession, "__aexit__", mock_exit):
+            with pytest.raises(ValueError, match="boom"):
+                await requestor.arequest("POST", "/test", params={})
+
+        mock_exit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_arequest_cleans_up_session_on_success(self):
+        requestor = APIRequestor(key="dummy")
+
+        mock_exit = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.release = lambda: None
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.read = AsyncMock(return_value=b'{"data": []}')
+
+        async def ok_arequest_raw(*args, **kwargs):
+            return mock_response
+
+        with patch.object(requestor, "arequest_raw", side_effect=ok_arequest_raw), \
+             patch.object(AioHTTPSession, "__aexit__", mock_exit):
+            await requestor.arequest("POST", "/test", params={})
+
+        mock_exit.assert_awaited_once()

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -322,11 +322,11 @@ class TestAsyncCancellationCleanup:
         async def slow_arequest_raw(*args, **kwargs):
             await asyncio.sleep(3600)
 
-        with patch.object(requestor, "arequest_raw", side_effect=slow_arequest_raw), \
-             patch.object(AioHTTPSession, "__aexit__", mock_exit):
-            task = asyncio.create_task(
-                requestor.arequest("POST", "/test", params={})
-            )
+        with (
+            patch.object(requestor, "arequest_raw", side_effect=slow_arequest_raw),
+            patch.object(AioHTTPSession, "__aexit__", mock_exit),
+        ):
+            task = asyncio.create_task(requestor.arequest("POST", "/test", params={}))
             await asyncio.sleep(0.05)
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -343,8 +343,10 @@ class TestAsyncCancellationCleanup:
         async def failing_arequest_raw(*args, **kwargs):
             raise ValueError("boom")
 
-        with patch.object(requestor, "arequest_raw", side_effect=failing_arequest_raw), \
-             patch.object(AioHTTPSession, "__aexit__", mock_exit):
+        with (
+            patch.object(requestor, "arequest_raw", side_effect=failing_arequest_raw),
+            patch.object(AioHTTPSession, "__aexit__", mock_exit),
+        ):
             with pytest.raises(ValueError, match="boom"):
                 await requestor.arequest("POST", "/test", params={})
 
@@ -364,8 +366,10 @@ class TestAsyncCancellationCleanup:
         async def ok_arequest_raw(*args, **kwargs):
             return mock_response
 
-        with patch.object(requestor, "arequest_raw", side_effect=ok_arequest_raw), \
-             patch.object(AioHTTPSession, "__aexit__", mock_exit):
+        with (
+            patch.object(requestor, "arequest_raw", side_effect=ok_arequest_raw),
+            patch.object(AioHTTPSession, "__aexit__", mock_exit),
+        ):
             await requestor.arequest("POST", "/test", params={})
 
         mock_exit.assert_awaited_once()

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import voyageai
 import voyageai.error as error
-from voyageai.api_resources.api_requestor import APIRequestor, AioHTTPSession
+from voyageai.api_resources.api_requestor import AioHTTPSession, APIRequestor
 from voyageai.chunking import default_chunk_fn
 
 

--- a/voyageai/api_resources/api_requestor.py
+++ b/voyageai/api_resources/api_requestor.py
@@ -172,17 +172,11 @@ class APIRequestor:
                 request_timeout=request_timeout,
             )
             resp = await self._interpret_async_response(result)
-        except Exception:
-            # Close the request before exiting session context.
+            return resp
+        finally:
             if result is not None:
                 result.release()
             await ctx.__aexit__(None, None, None)
-            raise
-
-        # Close the request before exiting session context.
-        result.release()
-        await ctx.__aexit__(None, None, None)
-        return resp
 
     def request_headers(self, method: str, extra, request_id: Optional[str]) -> Dict[str, str]:
         user_agent = "Voyage/v1 PythonBindings/%s" % (version.VERSION,)


### PR DESCRIPTION
## Summary
- Replace `except Exception` with `try/finally` in `APIRequestor.arequest()` so that `asyncio.CancelledError` (a `BaseException` since Python 3.9) properly triggers session cleanup instead of leaking the `aiohttp.ClientSession`.

## What changed
The cleanup path in `arequest()` used manual `__aenter__`/`__aexit__` with an `except Exception` guard. Since `CancelledError` is a `BaseException`, cancelling the coroutine skipped `ctx.__aexit__()` entirely, leaving the session unclosed. Switching to `try/finally` ensures cleanup runs on success, exception, and cancellation alike.

## Test plan
- [x] 3 new unit tests covering cleanup on cancellation, exception, and success (no API key needed)
- [x] Full async integration test suite passes (20/20)

Fixes #52