### PR TITLE
Local model (voyage-4-nano) support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,17 +7,18 @@ on:
     branches: [ "main" ]
   workflow_call:
 
+env:
+  POETRY_HOME: "/opt/poetry"
+
 jobs:
-  test:
-    name: Tests
+  # Unit tests without local dependencies (tests import error handling)
+  unit-tests-no-local-deps:
+    name: Unit Tests (no local deps)
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-    env:
-      VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
-      POETRY_HOME: "/opt/poetry"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -38,7 +39,75 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ffmpeg
         ffmpeg -version
-    - name: Install package
+    - name: Install package (without local extras)
       run: $POETRY_HOME/bin/poetry install
-    - name: Run tests
+    - name: Run unit tests (no API key, no local deps)
+      run: $POETRY_HOME/bin/poetry run pytest tests/test_client_local.py tests/test_client_local_async.py -v
+
+  # Local model tests with local dependencies but no API key
+  local-model-tests:
+    name: Local Model Tests
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install poetry
+      run: |
+        python3 -m venv $POETRY_HOME
+        $POETRY_HOME/bin/pip install poetry==1.8.4
+        $POETRY_HOME/bin/poetry --version
+    - name: Install ffmpeg 7
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
+        ffmpeg -version
+    - name: Install package with local extras
+      run: $POETRY_HOME/bin/poetry install --extras local
+    - name: Run local model tests (no API key)
+      run: $POETRY_HOME/bin/poetry run pytest tests/test_client_local.py tests/test_client_local_async.py -v
+
+  # Full integration tests with API key and all dependencies
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+    env:
+      VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install poetry
+      run: |
+        python3 -m venv $POETRY_HOME
+        $POETRY_HOME/bin/pip install poetry==1.8.4
+        $POETRY_HOME/bin/poetry --version
+    - name: Install ffmpeg 7
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
+        ffmpeg -version
+    - name: Install package with local extras
+      run: $POETRY_HOME/bin/poetry install --extras local
+    - name: Run all tests
       run: $POETRY_HOME/bin/poetry run pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,14 +45,13 @@ jobs:
       run: $POETRY_HOME/bin/poetry run pytest tests/test_client_local.py tests/test_client_local_async.py -v
 
   # Local model tests with local dependencies but no API key
-  # Requires Python 3.10+ because the HuggingFace model code uses 3.10+ syntax
   local-model-tests:
     name: Local Model Tests
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -81,14 +80,13 @@ jobs:
       run: $POETRY_HOME/bin/poetry run pytest tests/test_client_local.py tests/test_client_local_async.py -v
 
   # Full integration tests with API key and all dependencies
-  # Requires Python 3.10+ for local model deps (HuggingFace model uses 3.10+ syntax)
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,11 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      # Run one Python version at a time: every job here hits the live API
+      # (incl. token-heavy voyage-multimodal-3.5), and running the whole matrix
+      # in parallel exceeds the project's per-minute token (TPM) rate limit,
+      # turning real assertions into spurious RateLimitError failures.
+      max-parallel: 1
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,13 +45,14 @@ jobs:
       run: $POETRY_HOME/bin/poetry run pytest tests/test_client_local.py tests/test_client_local_async.py -v
 
   # Local model tests with local dependencies but no API key
+  # Requires Python 3.10+ because the HuggingFace model code uses 3.10+ syntax
   local-model-tests:
     name: Local Model Tests
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -72,19 +73,22 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ffmpeg
         ffmpeg -version
+    - name: Install OpenBLAS (needed for scipy build on 3.13+)
+      run: sudo apt-get install -y libopenblas-dev
     - name: Install package with local extras
       run: $POETRY_HOME/bin/poetry install --extras local
     - name: Run local model tests (no API key)
       run: $POETRY_HOME/bin/poetry run pytest tests/test_client_local.py tests/test_client_local_async.py -v
 
   # Full integration tests with API key and all dependencies
+  # Requires Python 3.10+ for local model deps (HuggingFace model uses 3.10+ syntax)
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
     steps:
@@ -107,6 +111,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ffmpeg
         ffmpeg -version
+    - name: Install OpenBLAS (needed for scipy build on 3.13+)
+      run: sudo apt-get install -y libopenblas-dev
     - name: Install package with local extras
       run: $POETRY_HOME/bin/poetry install --extras local
     - name: Run all tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install poetry
@@ -54,9 +54,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install poetry
@@ -91,9 +91,9 @@ jobs:
       VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install poetry

--- a/README.md
+++ b/README.md
@@ -10,4 +10,37 @@ Voyage AI provides API endpoints for embedding and reranking models that take in
 
 Voyage AI’s embedding models and rerankers are **state-of-the-art** in retrieval accuracy. Please read our announcing [blog post](https://blog.voyageai.com/2023/10/29/voyage-embeddings/) for details.  Please also check out a high-level [introduction](https://www.pinecone.io/learn/retrieval-augmented-generation/) of embedding models, semantic search, and RAG, and our step-by-step [quickstart tutorial](https://docs.voyageai.com/docs/quickstart-tutorial) on implementing a minimalist RAG chatbot using Voyage model endpoints.
 
+## Local models (`voyage-4-nano`)
+
+`voyage-4-nano` can run **locally**, without an API key, via
+[sentence-transformers](https://www.sbert.net/). Install the optional extra:
+
+```bash
+pip install "voyageai[local]"
+```
+
+Requirements:
+
+- **Python 3.10+** (the local model's code uses 3.10+ typing syntax). On older
+  Python the extra is skipped and local models are unavailable.
+- The extra pulls in `torch` and `sentence-transformers`; a pure-API install of
+  `voyageai` never imports them, so API-only users pay no import cost.
+
+Usage is identical to the hosted API — just pass the local model name; no API key
+is required:
+
+```python
+import voyageai
+
+vo = voyageai.Client()  # no API key needed for local models
+result = vo.embed(["Hello, world!"], model="voyage-4-nano", input_type="document")
+print(result.embeddings[0])
+```
+
+The local path mirrors the hosted API's behavior (input validation, unit-norm
+Matryoshka embeddings at every dimension, token accounting, and the 1000-input
+batch limit). `int8`/`uint8` output dtypes are the one exception — they require
+fixed calibration ranges we don't ship locally yet and raise `NotImplementedError`;
+use `float`/`float32` or `binary`/`ubinary` instead.
+
 ### [Voyage AI Official Documentation](https://docs.voyageai.com)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = "*"
-sentence-transformers = {version = ">=3.0.0", optional = true, python = ">=3.10"}
+sentence-transformers = {version = ">=3.0.0,<5.0.0", optional = true, python = ">=3.10"}
 torch = {version = ">=2.9.0", optional = true, python = ">=3.10"}
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = "*"
 sentence-transformers = {version = ">=3.0.0", optional = true}
-torch = {version = ">=2.0.0", optional = true}
+torch = {version = ">=2.9.0", optional = true}
 
 [tool.poetry.extras]
 local = ["sentence-transformers", "torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = "*"
-sentence-transformers = {version = ">=3.0.0", optional = true}
+sentence-transformers = {version = ">=3.0.0", optional = true, python = ">=3.10"}
 torch = {version = ">=2.9.0", optional = true, python = ">=3.10"}
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "voyageai"
-version = "0.3.8"
+version = "0.3.9"
 description = ""
 authors = ["Yujie Qian <yujieq@voyageai.com>"]
 readme = "README.md"
@@ -20,6 +20,11 @@ pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = "*"
+sentence-transformers = {version = ">=3.0.0", optional = true}
+torch = {version = ">=2.0.0", optional = true}
+
+[tool.poetry.extras]
+local = ["sentence-transformers", "torch"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"
@@ -39,6 +44,12 @@ ignore = ["E501"]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests as integration tests (require external dependencies or API)",
+]
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,17 @@ ffmpeg-python = {version = "*", optional = true}
 sentence-transformers = {version = ">=5.0.0", optional = true, python = ">=3.10"}
 torch = {version = ">=2.9.0", optional = true, python = ">=3.10"}
 transformers = {version = ">=4.41.0,<5.0.0", optional = true, python = ">=3.10"}
+# scipy is pulled in transitively by sentence-transformers (via scikit-learn).
+# Pin a modern floor: scipy 1.6.1 declares `Requires-Python: >=3.7` with no
+# upper bound, so the resolver otherwise selects it for 3.13/3.14, where it has
+# no wheels and fails to build from source. 1.14.1 is the first release with
+# cp313 wheels; newer releases cover 3.14. (Only needed for the local extra,
+# which itself requires Python >=3.10.)
+scipy = {version = ">=1.14.1", optional = true, python = ">=3.10"}
 
 [tool.poetry.extras]
 video = ["ffmpeg-python"]
-local = ["sentence-transformers", "torch", "transformers"]
+local = ["sentence-transformers", "torch", "transformers", "scipy"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,12 @@ pydantic = ">=1.10.8"
 tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = "*"
-sentence-transformers = {version = ">=3.0.0,<5.0.0", optional = true, python = ">=3.10"}
+sentence-transformers = {version = ">=5.0.0", optional = true, python = ">=3.10"}
 torch = {version = ">=2.9.0", optional = true, python = ">=3.10"}
+transformers = {version = ">=4.41.0,<5.0.0", optional = true, python = ">=3.10"}
 
 [tool.poetry.extras]
-local = ["sentence-transformers", "torch"]
+local = ["sentence-transformers", "torch", "transformers"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = "*"
 sentence-transformers = {version = ">=3.0.0", optional = true}
-torch = {version = ">=2.9.0", optional = true}
+torch = {version = ">=2.9.0", optional = true, python = ">=3.10"}
 
 [tool.poetry.extras]
 local = ["sentence-transformers", "torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,13 @@ pydantic = ">=2.7.4"
 tokenizers = ">=0.14.0"
 langchain-text-splitters = ">=0.3.8"
 ffmpeg-python = {version = "*", optional = true}
-sentence-transformers = {version = ">=5.0.0", optional = true, python = ">=3.10"}
+sentence-transformers = {version = ">=5.5.0", optional = true, python = ">=3.10"}
 torch = {version = ">=2.9.0", optional = true, python = ">=3.10"}
 transformers = {version = ">=4.41.0,<5.0.0", optional = true, python = ">=3.10"}
+# Floor is 5.5.0: the per-call processing_kwargs override that encode() relies on
+# to honor truncation=False was added there (PR #3753). On earlier 5.x the kwarg
+# is unknown, so truncation=False would be silently ignored and long inputs
+# truncated anyway.
 # scipy is pulled in transitively by sentence-transformers (via scikit-learn).
 # Pin a modern floor: scipy 1.6.1 declares `Requires-Python: >=3.7` with no
 # upper bound, so the resolver otherwise selects it for 3.13/3.14, where it has

--- a/tests/_local_test_utils.py
+++ b/tests/_local_test_utils.py
@@ -1,0 +1,17 @@
+"""Shared helpers for the local-model test modules."""
+
+import importlib.util
+
+
+def real_deps_available() -> bool:
+    """Check if sentence-transformers and torch can be found (without importing).
+
+    Deliberately uses ``importlib.util.find_spec`` rather than
+    ``voyageai.local._is_local_available`` so it stays an *independent* signal:
+    ``test_has_local_constant`` asserts ``voyageai.HAS_LOCAL`` against this, and
+    that assertion is only meaningful if the two are computed differently.
+    """
+    return (
+        importlib.util.find_spec("sentence_transformers") is not None
+        and importlib.util.find_spec("torch") is not None
+    )

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -217,6 +217,45 @@ class TestLocalModelIntegration:
             norm = np.linalg.norm(result.embeddings[0])
             assert norm == pytest.approx(1.0, abs=1e-2), f"dim={dim} not unit-norm (norm={norm})"
 
+    def test_truncation_false_over_length_raises(self):
+        """truncation=False on over-length input raises InvalidRequestError, matching
+        the hosted API, instead of crashing/degrading inside the model."""
+        from voyageai import Client
+
+        client = Client()
+        long_text = "word " * 40000  # well beyond the 32768-token context limit
+
+        with pytest.raises(InvalidRequestError):
+            client.embed([long_text], model="voyage-4-nano", truncation=False)
+
+    def test_total_tokens_capped_when_truncated(self):
+        """With truncation on, total_tokens reports the processed (capped) count,
+        not the full pre-truncation length, matching the API."""
+        from voyageai import Client
+
+        client = Client()
+        long_text = "word " * 40000
+
+        result = client.embed([long_text], model="voyage-4-nano", truncation=True)
+        assert result.total_tokens <= 32768
+
+
+class TestLocalInputValidation:
+    """Empty / None input must raise InvalidRequestError like the hosted API.
+    These raise before any model load, so they need no local deps or network."""
+
+    def test_empty_list_raises(self):
+        from voyageai import Client
+
+        with pytest.raises(InvalidRequestError):
+            Client().embed([], model="voyage-4-nano")
+
+    def test_none_input_raises(self):
+        from voyageai import Client
+
+        with pytest.raises(InvalidRequestError):
+            Client().embed(None, model="voyage-4-nano")
+
 
 class TestKeylessApiGate:
     """A keyless client is allowed (for local models) but every API-backed method
@@ -258,3 +297,20 @@ class TestKeylessApiGate:
 
         with pytest.raises(voyageai.error.AuthenticationError):
             keyless_client.embed(["hello"], model="voyage-3")
+
+    def test_binary_key_file_falls_back_to_keyless(self, tmp_path, monkeypatch):
+        """A non-UTF-8 VOYAGE_API_KEY_PATH raises UnicodeDecodeError in
+        default_api_key(); construction must tolerate it and fall back to keyless
+        rather than crash."""
+        import voyageai
+        from voyageai import Client
+
+        key_file = tmp_path / "key.bin"
+        key_file.write_bytes(b"\xff\xfe\x00\x01")
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        monkeypatch.setattr(voyageai, "api_key", None, raising=False)
+        monkeypatch.setattr(voyageai, "api_key_path", None, raising=False)
+        monkeypatch.setenv("VOYAGE_API_KEY_PATH", str(key_file))
+
+        client = Client()  # must not raise UnicodeDecodeError
+        assert client.api_key is None

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -13,6 +13,18 @@ try:
 except ImportError:
     REAL_DEPS_AVAILABLE = False
 
+# Check if local model can actually load (fails on Python <3.10 due to
+# HuggingFace model code using 3.10+ type union syntax)
+LOCAL_MODEL_WORKS = False
+if REAL_DEPS_AVAILABLE:
+    try:
+        from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+        SentenceTransformerBackend("voyage-4-nano")
+        LOCAL_MODEL_WORKS = True
+    except (TypeError, Exception):
+        pass
+
 
 class TestLocalModelSupport:
     """Test local model detection and routing."""
@@ -43,9 +55,11 @@ class TestLocalModelIntegration:
 
     @pytest.fixture
     def check_deps(self):
-        """Skip if dependencies not installed."""
+        """Skip if dependencies not installed or model can't load."""
         if not REAL_DEPS_AVAILABLE:
             pytest.skip("sentence-transformers or torch not installed")
+        if not LOCAL_MODEL_WORKS:
+            pytest.skip("local model failed to load (requires Python 3.10+)")
 
     def test_seamless_local_embedding(self, check_deps):
         """Test that Client.embed() seamlessly uses local model."""

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -1,20 +1,11 @@
 """Tests for local model support in Client."""
 
-import importlib.util
-
 import pytest
 from voyageai.error import InvalidRequestError
 
+from tests._local_test_utils import real_deps_available
 
-def _real_deps_available() -> bool:
-    """Check if sentence-transformers and torch can be found (without importing)."""
-    return (
-        importlib.util.find_spec("sentence_transformers") is not None
-        and importlib.util.find_spec("torch") is not None
-    )
-
-
-REAL_DEPS_AVAILABLE = _real_deps_available()
+REAL_DEPS_AVAILABLE = real_deps_available()
 
 
 @pytest.fixture(scope="session")
@@ -60,7 +51,7 @@ class TestLocalModelSupport:
         """Test HAS_LOCAL reflects dependency availability via independent check."""
         import voyageai
 
-        expected = _real_deps_available()
+        expected = real_deps_available()
         assert voyageai.HAS_LOCAL == expected
 
 

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -1,0 +1,132 @@
+"""Tests for local model support in Client."""
+
+import pytest
+
+# ruff: noqa: F401
+
+# Check if real dependencies are available
+try:
+    import sentence_transformers
+    import torch
+
+    REAL_DEPS_AVAILABLE = True
+except ImportError:
+    REAL_DEPS_AVAILABLE = False
+
+
+class TestLocalModelSupport:
+    """Test local model detection and routing."""
+
+    @pytest.mark.skipif(REAL_DEPS_AVAILABLE, reason="Only run when deps not installed")
+    def test_import_error_when_deps_missing(self):
+        """Test helpful error message when sentence-transformers not installed."""
+        from voyageai.local import _ensure_local_deps
+
+        with pytest.raises(ImportError) as exc_info:
+            _ensure_local_deps()
+
+        assert "pip install voyageai[local]" in str(exc_info.value)
+
+    def test_has_local_constant(self):
+        """Test HAS_LOCAL constant reflects dependency availability."""
+        import voyageai
+
+        assert voyageai.HAS_LOCAL == REAL_DEPS_AVAILABLE
+
+
+@pytest.mark.integration
+class TestLocalModelIntegration:
+    """Integration tests for local models using the standard Client.
+
+    Run with: pytest -m integration
+    """
+
+    @pytest.fixture
+    def check_deps(self):
+        """Skip if dependencies not installed."""
+        if not REAL_DEPS_AVAILABLE:
+            pytest.skip("sentence-transformers or torch not installed")
+
+    def test_seamless_local_embedding(self, check_deps):
+        """Test that Client.embed() seamlessly uses local model."""
+        from voyageai import Client
+
+        # No API key needed for local models
+        client = Client()
+        result = client.embed(["Hello, world!"], model="voyage-4-nano", input_type="document")
+
+        assert len(result.embeddings) == 1
+        assert len(result.embeddings[0]) == 2048
+        assert result.total_tokens > 0
+
+    def test_all_dimensions(self, check_deps):
+        """Test all supported dimensions work."""
+        from voyageai import Client
+
+        client = Client()
+
+        for dim in [256, 512, 1024, 2048]:
+            result = client.embed(
+                ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
+            )
+            assert len(result.embeddings[0]) == dim, f"Expected {dim}, got {len(result.embeddings[0])}"
+
+    def test_float32_dtype(self, check_deps):
+        """Test float32 output data type (default)."""
+        from voyageai import Client
+
+        client = Client()
+
+        result = client.embed(["Test"], model="voyage-4-nano", input_type="document", output_dtype="float32")
+        assert isinstance(result.embeddings[0][0], float)
+
+    def test_query_vs_document_different(self, check_deps):
+        """Test query and document embeddings are different."""
+        from voyageai import Client
+
+        client = Client()
+
+        query_result = client.embed(["What is machine learning?"], model="voyage-4-nano", input_type="query")
+        doc_result = client.embed(["What is machine learning?"], model="voyage-4-nano", input_type="document")
+
+        # Embeddings should be different due to different prompts
+        assert query_result.embeddings[0] != doc_result.embeddings[0]
+
+    def test_batch_embedding(self, check_deps):
+        """Test batch embedding works."""
+        from voyageai import Client
+
+        client = Client()
+
+        texts = [
+            "First document",
+            "Second document",
+            "Third document",
+        ]
+        result = client.embed(texts, model="voyage-4-nano", input_type="document")
+
+        assert len(result.embeddings) == 3
+        for emb in result.embeddings:
+            assert len(emb) == 2048
+
+    def test_invalid_dimension_raises_error(self, check_deps):
+        """Test invalid dimension raises ValueError."""
+        from voyageai import Client
+
+        client = Client()
+
+        with pytest.raises(ValueError) as exc_info:
+            client.embed(["test"], model="voyage-4-nano", output_dimension=999)
+
+        assert "Invalid output_dimension" in str(exc_info.value)
+
+    def test_invalid_dtype_raises_error(self, check_deps):
+        """Test invalid dtype raises ValueError."""
+        from voyageai import Client
+
+        client = Client()
+
+        with pytest.raises(ValueError) as exc_info:
+            client.embed(["test"], model="voyage-4-nano", output_dtype="invalid")
+
+        assert "Invalid output_dtype" in str(exc_info.value)

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -256,6 +256,14 @@ class TestLocalInputValidation:
         with pytest.raises(InvalidRequestError):
             Client().embed(None, model="voyage-4-nano")
 
+    def test_batch_over_limit_raises(self):
+        """A batch larger than the documented 1000-input limit must raise
+        InvalidRequestError, matching the hosted API (rejected before model load)."""
+        from voyageai import Client
+
+        with pytest.raises(InvalidRequestError):
+            Client().embed(["x"] * 1001, model="voyage-4-nano")
+
 
 class TestKeylessApiGate:
     """A keyless client is allowed (for local models) but every API-backed method

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -176,3 +176,93 @@ class TestLocalModelIntegration:
             client.embed(["test"], model="voyage-4-nano", output_dtype="invalid")
 
         assert "Invalid output_dtype" in str(exc_info.value)
+
+    def test_bare_string_returns_nested_list(self):
+        """Bare string input must return a list with one embedding, matching the API."""
+        from voyageai import Client
+
+        client = Client()
+
+        result = client.embed("Hello, world!", model="voyage-4-nano", input_type="document")
+
+        assert len(result.embeddings) == 1
+        assert len(result.embeddings[0]) == 2048
+        assert isinstance(result.embeddings[0][0], float)
+
+    def test_invalid_input_type_raises_error(self):
+        """An unknown input_type must raise, not silently degrade to no prompt."""
+        from voyageai import Client
+
+        client = Client()
+
+        with pytest.raises(ValueError) as exc_info:
+            client.embed(["test"], model="voyage-4-nano", input_type="doc")
+
+        assert "Invalid input_type" in str(exc_info.value)
+
+    def test_int8_dtype_not_supported(self):
+        """int8/uint8 require fixed calibration ranges and must be rejected locally."""
+        from voyageai import Client
+
+        client = Client()
+
+        for dtype in ("int8", "uint8"):
+            with pytest.raises(NotImplementedError) as exc_info:
+                client.embed(["test"], model="voyage-4-nano", output_dtype=dtype)
+            assert "calibration ranges" in str(exc_info.value)
+
+    def test_truncated_dimensions_are_unit_norm(self):
+        """Matryoshka-truncated embeddings must stay unit-norm like the API."""
+        import numpy as np
+        from voyageai import Client
+
+        client = Client()
+
+        for dim in [256, 512, 1024, 2048]:
+            result = client.embed(
+                ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
+            )
+            norm = np.linalg.norm(result.embeddings[0])
+            assert norm == pytest.approx(1.0, abs=1e-2), f"dim={dim} not unit-norm (norm={norm})"
+
+
+class TestKeylessApiGate:
+    """A keyless client is allowed (for local models) but every API-backed method
+    must fail fast with a clear AuthenticationError instead of late and deep in
+    the request layer. No model load or network access is required for these.
+    """
+
+    @pytest.fixture
+    def keyless_client(self, monkeypatch):
+        import voyageai
+        from voyageai import Client
+
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        monkeypatch.delenv("VOYAGE_API_KEY_PATH", raising=False)
+        monkeypatch.setattr(voyageai, "api_key", None, raising=False)
+        monkeypatch.setattr(voyageai, "api_key_path", None, raising=False)
+        return Client()
+
+    def test_rerank_requires_api_key(self, keyless_client):
+        import voyageai
+
+        with pytest.raises(voyageai.error.AuthenticationError):
+            keyless_client.rerank("q", ["a", "b"], model="rerank-2")
+
+    def test_contextualized_embed_requires_api_key(self, keyless_client):
+        import voyageai
+
+        with pytest.raises(voyageai.error.AuthenticationError):
+            keyless_client.contextualized_embed([["a", "b"]], model="voyage-context-3")
+
+    def test_multimodal_embed_requires_api_key(self, keyless_client):
+        import voyageai
+
+        with pytest.raises(voyageai.error.AuthenticationError):
+            keyless_client.multimodal_embed([["hello"]], model="voyage-multimodal-3")
+
+    def test_embed_requires_api_key_for_api_model(self, keyless_client):
+        import voyageai
+
+        with pytest.raises(voyageai.error.AuthenticationError):
+            keyless_client.embed(["hello"], model="voyage-3")

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -42,12 +42,18 @@ class TestLocalModelSupport:
     @pytest.mark.skipif(REAL_DEPS_AVAILABLE, reason="Only run when deps not installed")
     def test_import_error_when_deps_missing(self):
         """Test helpful error message when sentence-transformers not installed."""
+        import sys
+
         from voyageai.local import _ensure_local_deps
 
         with pytest.raises(ImportError) as exc_info:
             _ensure_local_deps()
 
-        assert "pip install voyageai[local]" in str(exc_info.value)
+        msg = str(exc_info.value)
+        if sys.version_info < (3, 10):
+            assert "Python 3.10 or later" in msg
+        else:
+            assert "pip install voyageai[local]" in msg
 
     def test_has_local_constant(self):
         """Test HAS_LOCAL reflects dependency availability via independent check."""

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -69,9 +69,9 @@ class TestLocalModelIntegration:
             result = client.embed(
                 ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
             )
-            assert len(result.embeddings[0]) == dim, (
-                f"Expected {dim}, got {len(result.embeddings[0])}"
-            )
+            assert (
+                len(result.embeddings[0]) == dim
+            ), f"Expected {dim}, got {len(result.embeddings[0])}"
 
     def test_float32_dtype(self, check_deps):
         """Test float32 output data type (default)."""

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -3,7 +3,6 @@
 import importlib.util
 
 import pytest
-
 from voyageai.error import InvalidRequestError
 
 

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -69,7 +69,9 @@ class TestLocalModelIntegration:
             result = client.embed(
                 ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
             )
-            assert len(result.embeddings[0]) == dim, f"Expected {dim}, got {len(result.embeddings[0])}"
+            assert len(result.embeddings[0]) == dim, (
+                f"Expected {dim}, got {len(result.embeddings[0])}"
+            )
 
     def test_float32_dtype(self, check_deps):
         """Test float32 output data type (default)."""
@@ -77,7 +79,9 @@ class TestLocalModelIntegration:
 
         client = Client()
 
-        result = client.embed(["Test"], model="voyage-4-nano", input_type="document", output_dtype="float32")
+        result = client.embed(
+            ["Test"], model="voyage-4-nano", input_type="document", output_dtype="float32"
+        )
         assert isinstance(result.embeddings[0][0], float)
 
     def test_query_vs_document_different(self, check_deps):
@@ -86,8 +90,12 @@ class TestLocalModelIntegration:
 
         client = Client()
 
-        query_result = client.embed(["What is machine learning?"], model="voyage-4-nano", input_type="query")
-        doc_result = client.embed(["What is machine learning?"], model="voyage-4-nano", input_type="document")
+        query_result = client.embed(
+            ["What is machine learning?"], model="voyage-4-nano", input_type="query"
+        )
+        doc_result = client.embed(
+            ["What is machine learning?"], model="voyage-4-nano", input_type="document"
+        )
 
         # Embeddings should be different due to different prompts
         assert query_result.embeddings[0] != doc_result.embeddings[0]

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -4,6 +4,8 @@ import importlib.util
 
 import pytest
 
+from voyageai.error import InvalidRequestError
+
 
 def _real_deps_available() -> bool:
     """Check if sentence-transformers and torch can be found (without importing)."""
@@ -156,23 +158,23 @@ class TestLocalModelIntegration:
             assert len(emb) == 2048
 
     def test_invalid_dimension_raises_error(self):
-        """Test invalid dimension raises ValueError."""
+        """Invalid dimension raises InvalidRequestError, matching the hosted API."""
         from voyageai import Client
 
         client = Client()
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(InvalidRequestError) as exc_info:
             client.embed(["test"], model="voyage-4-nano", output_dimension=999)
 
         assert "Invalid output_dimension" in str(exc_info.value)
 
     def test_invalid_dtype_raises_error(self):
-        """Test invalid dtype raises ValueError."""
+        """Invalid dtype raises InvalidRequestError, matching the hosted API."""
         from voyageai import Client
 
         client = Client()
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(InvalidRequestError) as exc_info:
             client.embed(["test"], model="voyage-4-nano", output_dtype="invalid")
 
         assert "Invalid output_dtype" in str(exc_info.value)
@@ -195,7 +197,7 @@ class TestLocalModelIntegration:
 
         client = Client()
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(InvalidRequestError) as exc_info:
             client.embed(["test"], model="voyage-4-nano", input_type="doc")
 
         assert "Invalid input_type" in str(exc_info.value)

--- a/tests/test_client_local.py
+++ b/tests/test_client_local.py
@@ -1,29 +1,39 @@
 """Tests for local model support in Client."""
 
+import importlib.util
+
 import pytest
 
-# ruff: noqa: F401
 
-# Check if real dependencies are available
-try:
-    import sentence_transformers
-    import torch
+def _real_deps_available() -> bool:
+    """Check if sentence-transformers and torch can be found (without importing)."""
+    return (
+        importlib.util.find_spec("sentence_transformers") is not None
+        and importlib.util.find_spec("torch") is not None
+    )
 
-    REAL_DEPS_AVAILABLE = True
-except ImportError:
-    REAL_DEPS_AVAILABLE = False
 
-# Check if local model can actually load (fails on Python <3.10 due to
-# HuggingFace model code using 3.10+ type union syntax)
-LOCAL_MODEL_WORKS = False
-if REAL_DEPS_AVAILABLE:
+REAL_DEPS_AVAILABLE = _real_deps_available()
+
+
+@pytest.fixture(scope="session")
+def local_model_works():
+    """Check if the local model can actually load.
+
+    Fails on Python <3.10 due to HuggingFace model code using 3.10+ type
+    union syntax.
+    """
+    if not REAL_DEPS_AVAILABLE:
+        pytest.skip("sentence-transformers or torch not installed")
     try:
         from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
 
         SentenceTransformerBackend("voyage-4-nano")
-        LOCAL_MODEL_WORKS = True
-    except (TypeError, Exception):
-        pass
+        return True
+    except TypeError:
+        pytest.skip("local model failed to load (requires Python 3.10+)")
+    except ImportError:
+        pytest.skip("local model dependencies not available")
 
 
 class TestLocalModelSupport:
@@ -40,10 +50,11 @@ class TestLocalModelSupport:
         assert "pip install voyageai[local]" in str(exc_info.value)
 
     def test_has_local_constant(self):
-        """Test HAS_LOCAL constant reflects dependency availability."""
+        """Test HAS_LOCAL reflects dependency availability via independent check."""
         import voyageai
 
-        assert voyageai.HAS_LOCAL == REAL_DEPS_AVAILABLE
+        expected = _real_deps_available()
+        assert voyageai.HAS_LOCAL == expected
 
 
 @pytest.mark.integration
@@ -53,15 +64,11 @@ class TestLocalModelIntegration:
     Run with: pytest -m integration
     """
 
-    @pytest.fixture
-    def check_deps(self):
-        """Skip if dependencies not installed or model can't load."""
-        if not REAL_DEPS_AVAILABLE:
-            pytest.skip("sentence-transformers or torch not installed")
-        if not LOCAL_MODEL_WORKS:
-            pytest.skip("local model failed to load (requires Python 3.10+)")
+    @pytest.fixture(autouse=True)
+    def _require_local_model(self, local_model_works):
+        """Skip all tests in this class if local model can't load."""
 
-    def test_seamless_local_embedding(self, check_deps):
+    def test_seamless_local_embedding(self):
         """Test that Client.embed() seamlessly uses local model."""
         from voyageai import Client
 
@@ -73,7 +80,7 @@ class TestLocalModelIntegration:
         assert len(result.embeddings[0]) == 2048
         assert result.total_tokens > 0
 
-    def test_all_dimensions(self, check_deps):
+    def test_all_dimensions(self):
         """Test all supported dimensions work."""
         from voyageai import Client
 
@@ -87,7 +94,7 @@ class TestLocalModelIntegration:
                 len(result.embeddings[0]) == dim
             ), f"Expected {dim}, got {len(result.embeddings[0])}"
 
-    def test_float32_dtype(self, check_deps):
+    def test_float32_dtype(self):
         """Test float32 output data type (default)."""
         from voyageai import Client
 
@@ -98,7 +105,18 @@ class TestLocalModelIntegration:
         )
         assert isinstance(result.embeddings[0][0], float)
 
-    def test_query_vs_document_different(self, check_deps):
+    def test_float_dtype(self):
+        """Test 'float' output_dtype works (alias for float32)."""
+        from voyageai import Client
+
+        client = Client()
+
+        result = client.embed(
+            ["Test"], model="voyage-4-nano", input_type="document", output_dtype="float"
+        )
+        assert isinstance(result.embeddings[0][0], float)
+
+    def test_query_vs_document_different(self):
         """Test query and document embeddings are different."""
         from voyageai import Client
 
@@ -114,7 +132,7 @@ class TestLocalModelIntegration:
         # Embeddings should be different due to different prompts
         assert query_result.embeddings[0] != doc_result.embeddings[0]
 
-    def test_batch_embedding(self, check_deps):
+    def test_batch_embedding(self):
         """Test batch embedding works."""
         from voyageai import Client
 
@@ -131,7 +149,7 @@ class TestLocalModelIntegration:
         for emb in result.embeddings:
             assert len(emb) == 2048
 
-    def test_invalid_dimension_raises_error(self, check_deps):
+    def test_invalid_dimension_raises_error(self):
         """Test invalid dimension raises ValueError."""
         from voyageai import Client
 
@@ -142,7 +160,7 @@ class TestLocalModelIntegration:
 
         assert "Invalid output_dimension" in str(exc_info.value)
 
-    def test_invalid_dtype_raises_error(self, check_deps):
+    def test_invalid_dtype_raises_error(self):
         """Test invalid dtype raises ValueError."""
         from voyageai import Client
 

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -1,20 +1,12 @@
 """Tests for async local model support in AsyncClient."""
 
 import asyncio
-import importlib.util
 
 import pytest
 
+from tests._local_test_utils import real_deps_available
 
-def _real_deps_available() -> bool:
-    """Check if sentence-transformers and torch can be found (without importing)."""
-    return (
-        importlib.util.find_spec("sentence_transformers") is not None
-        and importlib.util.find_spec("torch") is not None
-    )
-
-
-REAL_DEPS_AVAILABLE = _real_deps_available()
+REAL_DEPS_AVAILABLE = real_deps_available()
 
 
 @pytest.mark.integration

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -1,31 +1,20 @@
 """Tests for async local model support in AsyncClient."""
 
 import asyncio
+import importlib.util
 
 import pytest
 
-# ruff: noqa: F401
 
-# Check if real dependencies are available
-try:
-    import sentence_transformers
-    import torch
+def _real_deps_available() -> bool:
+    """Check if sentence-transformers and torch can be found (without importing)."""
+    return (
+        importlib.util.find_spec("sentence_transformers") is not None
+        and importlib.util.find_spec("torch") is not None
+    )
 
-    REAL_DEPS_AVAILABLE = True
-except ImportError:
-    REAL_DEPS_AVAILABLE = False
 
-# Check if local model can actually load (fails on Python <3.10 due to
-# HuggingFace model code using 3.10+ type union syntax)
-LOCAL_MODEL_WORKS = False
-if REAL_DEPS_AVAILABLE:
-    try:
-        from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
-
-        SentenceTransformerBackend("voyage-4-nano")
-        LOCAL_MODEL_WORKS = True
-    except (TypeError, Exception):
-        pass
+REAL_DEPS_AVAILABLE = _real_deps_available()
 
 
 @pytest.mark.integration
@@ -35,13 +24,25 @@ class TestAsyncLocalModelIntegration:
     Run with: pytest -m integration
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def check_deps(self):
-        """Skip if dependencies not installed or model can't load."""
+        """Skip if dependencies not installed or model can't load.
+
+        Loading happens here (not at import/collection time) and only the
+        documented failure modes are swallowed: a genuinely broken backend
+        (download error, OOM, runtime error) must surface, not turn into a
+        misleading skip.
+        """
         if not REAL_DEPS_AVAILABLE:
             pytest.skip("sentence-transformers or torch not installed")
-        if not LOCAL_MODEL_WORKS:
+        try:
+            from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+            SentenceTransformerBackend("voyage-4-nano")
+        except TypeError:
             pytest.skip("local model failed to load (requires Python 3.10+)")
+        except ImportError:
+            pytest.skip("local model dependencies not available")
 
     @pytest.mark.asyncio
     async def test_seamless_async_local_embedding(self, check_deps):

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -49,8 +49,15 @@ class TestAsyncLocalModelIntegration:
         assert result.total_tokens > 0
 
     @pytest.mark.asyncio
-    async def test_concurrent_local_embeddings(self, check_deps):
-        """Test concurrent local embedding calls."""
+    async def test_concurrent_local_embeds_return_correct_results(self, check_deps):
+        """Concurrently-dispatched local embeds each return a correct result.
+
+        Note: these are dispatched concurrently (asyncio.gather over
+        asyncio.to_thread), but the per-model inference lock serializes the
+        actual forward passes on the shared cached model — so this verifies
+        correctness under concurrent dispatch, not parallel execution. (A batched
+        encode would be the path to real parallelism if throughput matters.)
+        """
         from voyageai import AsyncClient
 
         client = AsyncClient()
@@ -111,3 +118,54 @@ class TestAsyncLocalModelIntegration:
             ["First", "Second", "Third"], model="voyage-4-nano", input_type="document"
         )
         assert len(result.embeddings) == 3
+
+    @pytest.mark.asyncio
+    async def test_async_invalid_input_type_raises(self, check_deps):
+        """Unknown input_type must raise on the async path too, matching the API."""
+        from voyageai import AsyncClient
+        from voyageai.error import InvalidRequestError
+
+        client = AsyncClient()
+        with pytest.raises(InvalidRequestError):
+            await client.embed(["test"], model="voyage-4-nano", input_type="doc")
+
+    @pytest.mark.asyncio
+    async def test_async_truncation_false_over_length_raises(self, check_deps):
+        """truncation=False on over-length input must raise on the async path too."""
+        from voyageai import AsyncClient
+        from voyageai.error import InvalidRequestError
+
+        client = AsyncClient()
+        long_text = "word " * 40000
+        with pytest.raises(InvalidRequestError):
+            await client.embed([long_text], model="voyage-4-nano", truncation=False)
+
+
+class TestAsyncLocalInputValidation:
+    """Empty / None / oversized-batch input must raise InvalidRequestError on the
+    async path too, matching the sync path and the hosted API. These raise before
+    any model load, so they need no local deps or network."""
+
+    @pytest.mark.asyncio
+    async def test_async_empty_list_raises(self):
+        from voyageai import AsyncClient
+        from voyageai.error import InvalidRequestError
+
+        with pytest.raises(InvalidRequestError):
+            await AsyncClient().embed([], model="voyage-4-nano")
+
+    @pytest.mark.asyncio
+    async def test_async_none_input_raises(self):
+        from voyageai import AsyncClient
+        from voyageai.error import InvalidRequestError
+
+        with pytest.raises(InvalidRequestError):
+            await AsyncClient().embed(None, model="voyage-4-nano")
+
+    @pytest.mark.asyncio
+    async def test_async_batch_over_limit_raises(self):
+        from voyageai import AsyncClient
+        from voyageai.error import InvalidRequestError
+
+        with pytest.raises(InvalidRequestError):
+            await AsyncClient().embed(["x"] * 1001, model="voyage-4-nano")

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -73,9 +73,9 @@ class TestAsyncLocalModelIntegration:
             result = await client.embed(
                 ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
             )
-            assert len(result.embeddings[0]) == dim, (
-                f"Expected {dim}, got {len(result.embeddings[0])}"
-            )
+            assert (
+                len(result.embeddings[0]) == dim
+            ), f"Expected {dim}, got {len(result.embeddings[0])}"
 
     @pytest.mark.asyncio
     async def test_async_query_vs_document(self, check_deps):

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -50,28 +50,34 @@ class TestAsyncLocalModelIntegration:
 
     @pytest.mark.asyncio
     async def test_concurrent_local_embeds_return_correct_results(self, check_deps):
-        """Concurrently-dispatched local embeds each return a correct result.
+        """Many concurrently-dispatched local embeds each return a correct result.
 
-        Note: these are dispatched concurrently (asyncio.gather over
-        asyncio.to_thread), but the per-model inference lock serializes the
-        actual forward passes on the shared cached model — so this verifies
-        correctness under concurrent dispatch, not parallel execution. (A batched
-        encode would be the path to real parallelism if throughput matters.)
+        These are dispatched concurrently (asyncio.gather over asyncio.to_thread),
+        but the per-model inference lock serializes ALL access to the shared cached
+        model — both tokenization and the forward pass. This is a regression guard
+        for the "RuntimeError: Already borrowed" race the Rust-backed HF fast
+        tokenizer raises when two threads tokenize at once: with enough contention
+        it reliably fired before the tokenization was moved under the lock. (It
+        verifies correctness under concurrent dispatch, not parallel execution — a
+        batched encode would be the path to real parallelism.)
         """
         from voyageai import AsyncClient
 
         client = AsyncClient()
 
-        texts = [
-            ["First document"],
-            ["Second document"],
-            ["Third document"],
+        # High contention across both routing branches to maximize the chance of
+        # surfacing a tokenizer/model data race if one is reintroduced.
+        tasks = [
+            client.embed(
+                [f"doc {i}"],
+                model="voyage-4-nano",
+                input_type="query" if i % 2 else "document",
+            )
+            for i in range(16)
         ]
-
-        tasks = [client.embed(t, model="voyage-4-nano", input_type="document") for t in texts]
         results = await asyncio.gather(*tasks)
 
-        assert len(results) == 3
+        assert len(results) == 16
         for result in results:
             assert len(result.embeddings) == 1
             assert len(result.embeddings[0]) == 2048

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -73,7 +73,9 @@ class TestAsyncLocalModelIntegration:
             result = await client.embed(
                 ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
             )
-            assert len(result.embeddings[0]) == dim, f"Expected {dim}, got {len(result.embeddings[0])}"
+            assert len(result.embeddings[0]) == dim, (
+                f"Expected {dim}, got {len(result.embeddings[0])}"
+            )
 
     @pytest.mark.asyncio
     async def test_async_query_vs_document(self, check_deps):
@@ -82,8 +84,12 @@ class TestAsyncLocalModelIntegration:
 
         client = AsyncClient()
 
-        query_result = await client.embed(["What is AI?"], model="voyage-4-nano", input_type="query")
-        doc_result = await client.embed(["What is AI?"], model="voyage-4-nano", input_type="document")
+        query_result = await client.embed(
+            ["What is AI?"], model="voyage-4-nano", input_type="query"
+        )
+        doc_result = await client.embed(
+            ["What is AI?"], model="voyage-4-nano", input_type="document"
+        )
 
         assert query_result.embeddings[0] != doc_result.embeddings[0]
 
@@ -98,4 +104,3 @@ class TestAsyncLocalModelIntegration:
             ["First", "Second", "Third"], model="voyage-4-nano", input_type="document"
         )
         assert len(result.embeddings) == 3
-

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -1,0 +1,101 @@
+"""Tests for async local model support in AsyncClient."""
+
+import asyncio
+
+import pytest
+
+# ruff: noqa: F401
+
+# Check if real dependencies are available
+try:
+    import sentence_transformers
+    import torch
+
+    REAL_DEPS_AVAILABLE = True
+except ImportError:
+    REAL_DEPS_AVAILABLE = False
+
+
+@pytest.mark.integration
+class TestAsyncLocalModelIntegration:
+    """Integration tests for async local models using the standard AsyncClient.
+
+    Run with: pytest -m integration
+    """
+
+    @pytest.fixture
+    def check_deps(self):
+        """Skip if dependencies not installed."""
+        if not REAL_DEPS_AVAILABLE:
+            pytest.skip("sentence-transformers or torch not installed")
+
+    @pytest.mark.asyncio
+    async def test_seamless_async_local_embedding(self, check_deps):
+        """Test that AsyncClient.embed() seamlessly uses local model."""
+        from voyageai import AsyncClient
+
+        client = AsyncClient()
+        result = await client.embed(["Hello, world!"], model="voyage-4-nano", input_type="document")
+
+        assert len(result.embeddings) == 1
+        assert len(result.embeddings[0]) == 2048
+        assert result.total_tokens > 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_local_embeddings(self, check_deps):
+        """Test concurrent local embedding calls."""
+        from voyageai import AsyncClient
+
+        client = AsyncClient()
+
+        texts = [
+            ["First document"],
+            ["Second document"],
+            ["Third document"],
+        ]
+
+        tasks = [client.embed(t, model="voyage-4-nano", input_type="document") for t in texts]
+        results = await asyncio.gather(*tasks)
+
+        assert len(results) == 3
+        for result in results:
+            assert len(result.embeddings) == 1
+            assert len(result.embeddings[0]) == 2048
+
+    @pytest.mark.asyncio
+    async def test_async_all_dimensions(self, check_deps):
+        """Test all supported dimensions in async context."""
+        from voyageai import AsyncClient
+
+        client = AsyncClient()
+
+        for dim in [256, 512, 1024, 2048]:
+            result = await client.embed(
+                ["Test text"], model="voyage-4-nano", input_type="document", output_dimension=dim
+            )
+            assert len(result.embeddings[0]) == dim, f"Expected {dim}, got {len(result.embeddings[0])}"
+
+    @pytest.mark.asyncio
+    async def test_async_query_vs_document(self, check_deps):
+        """Test query and document embeddings are different in async context."""
+        from voyageai import AsyncClient
+
+        client = AsyncClient()
+
+        query_result = await client.embed(["What is AI?"], model="voyage-4-nano", input_type="query")
+        doc_result = await client.embed(["What is AI?"], model="voyage-4-nano", input_type="document")
+
+        assert query_result.embeddings[0] != doc_result.embeddings[0]
+
+    @pytest.mark.asyncio
+    async def test_async_batch_embedding(self, check_deps):
+        """Test batch embedding in async context."""
+        from voyageai import AsyncClient
+
+        client = AsyncClient()
+
+        result = await client.embed(
+            ["First", "Second", "Third"], model="voyage-4-nano", input_type="document"
+        )
+        assert len(result.embeddings) == 3
+

--- a/tests/test_client_local_async.py
+++ b/tests/test_client_local_async.py
@@ -15,6 +15,18 @@ try:
 except ImportError:
     REAL_DEPS_AVAILABLE = False
 
+# Check if local model can actually load (fails on Python <3.10 due to
+# HuggingFace model code using 3.10+ type union syntax)
+LOCAL_MODEL_WORKS = False
+if REAL_DEPS_AVAILABLE:
+    try:
+        from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+        SentenceTransformerBackend("voyage-4-nano")
+        LOCAL_MODEL_WORKS = True
+    except (TypeError, Exception):
+        pass
+
 
 @pytest.mark.integration
 class TestAsyncLocalModelIntegration:
@@ -25,9 +37,11 @@ class TestAsyncLocalModelIntegration:
 
     @pytest.fixture
     def check_deps(self):
-        """Skip if dependencies not installed."""
+        """Skip if dependencies not installed or model can't load."""
         if not REAL_DEPS_AVAILABLE:
             pytest.skip("sentence-transformers or torch not installed")
+        if not LOCAL_MODEL_WORKS:
+            pytest.skip("local model failed to load (requires Python 3.10+)")
 
     @pytest.mark.asyncio
     async def test_seamless_async_local_embedding(self, check_deps):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -731,15 +731,22 @@ class TestBaseClient:
         c = voyageai.Client(api_key="test-key-abc")
         assert c.api_key == "test-key-abc"
 
-    def test_client_init_no_key_raises(self):
+    def test_client_init_no_key_is_keyless(self):
+        # Behavior change (local-model support): a missing API key no longer
+        # raises at construction — a keyless Client is allowed so local models
+        # (e.g. voyage-4-nano) can run without one. The key is only required when
+        # an API-backed method is actually called, which still raises
+        # AuthenticationError (here, before any network I/O).
         original_key = voyageai.api_key
         original_path = voyageai.api_key_path
         try:
             voyageai.api_key = None
             voyageai.api_key_path = None
             with patch.dict("os.environ", {}, clear=True):
+                client = voyageai.Client()
+                assert client.api_key is None
                 with pytest.raises(error.AuthenticationError):
-                    voyageai.Client()
+                    client.embed(["hello"], model="voyage-3")
         finally:
             voyageai.api_key = original_key
             voyageai.api_key_path = original_path

--- a/voyageai/__init__.py
+++ b/voyageai/__init__.py
@@ -36,6 +36,20 @@ from voyageai.embeddings_utils import (
 )
 from voyageai.version import VERSION
 
+
+def _is_local_available() -> bool:
+    """Check if sentence-transformers and torch are installed."""
+    try:
+        import sentence_transformers  # noqa: F401
+        import torch  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+HAS_LOCAL = _is_local_available()
+
 if TYPE_CHECKING:
     import requests
     from aiohttp import ClientSession

--- a/voyageai/__init__.py
+++ b/voyageai/__init__.py
@@ -37,33 +37,14 @@ from voyageai.embeddings_utils import (
 from voyageai.version import VERSION
 
 
-def _is_local_available() -> bool:
-    """Check if sentence-transformers and torch are installed (lazy, no eager import)."""
-    from voyageai.local import _is_local_available as _check
-
-    return _check()
-
-
-class _LazyLocalFlag:
-    """Descriptor that defers the local-availability check until first access."""
-
-    def __set_name__(self, owner, name):
-        self._name = name
-
-    def __get__(self, obj, objtype=None):
-        return _is_local_available()
-
-
-class _Module:
-    HAS_LOCAL = _LazyLocalFlag()
-
-
-_module_proxy = _Module()
-
-
 def __getattr__(name: str):
+    # `HAS_LOCAL` is resolved lazily so that `import voyageai` never imports
+    # torch / sentence-transformers; module-level __getattr__ already provides
+    # exactly this deferral on first attribute access.
     if name == "HAS_LOCAL":
-        return _module_proxy.HAS_LOCAL
+        from voyageai.local import _is_local_available
+
+        return _is_local_available()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/voyageai/__init__.py
+++ b/voyageai/__init__.py
@@ -38,17 +38,34 @@ from voyageai.version import VERSION
 
 
 def _is_local_available() -> bool:
-    """Check if sentence-transformers and torch are installed."""
-    try:
-        import sentence_transformers  # noqa: F401
-        import torch  # noqa: F401
+    """Check if sentence-transformers and torch are installed (lazy, no eager import)."""
+    from voyageai.local import _is_local_available as _check
 
-        return True
-    except ImportError:
-        return False
+    return _check()
 
 
-HAS_LOCAL = _is_local_available()
+class _LazyLocalFlag:
+    """Descriptor that defers the local-availability check until first access."""
+
+    def __set_name__(self, owner, name):
+        self._name = name
+
+    def __get__(self, obj, objtype=None):
+        return _is_local_available()
+
+
+class _Module:
+    HAS_LOCAL = _LazyLocalFlag()
+
+
+_module_proxy = _Module()
+
+
+def __getattr__(name: str):
+    if name == "HAS_LOCAL":
+        return _module_proxy.HAS_LOCAL
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 if TYPE_CHECKING:
     import requests

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -78,6 +78,21 @@ class _BaseClient(ABC):
             "base_url": base_url,
         }
 
+    def _require_api_key(self) -> None:
+        """Raise a clear error if no API key is configured.
+
+        The client allows a missing key so local models can run without one, but
+        every API-backed method must call this first. Otherwise a keyless call
+        would do its input validation/chunking and then fail late and deep inside
+        the request layer with a less actionable error.
+        """
+        if not self.api_key:
+            raise voyageai.error.AuthenticationError(
+                "An API key is required for API-based models. "
+                "Set your API key via the VOYAGE_API_KEY environment variable or "
+                "pass it to the client (api_key=...)."
+            )
+
     @abstractmethod
     def embed(
         self,

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -10,7 +10,7 @@ import PIL.Image
 from huggingface_hub import hf_hub_download
 
 import voyageai
-from voyageai.error import InvalidRequestError
+from voyageai.error import AuthenticationError, InvalidRequestError
 from voyageai.object import EmbeddingsObject, RerankingObject
 from voyageai.object.contextualized_embeddings import ContextualizedEmbeddingsObject
 from voyageai.object.multimodal_embeddings import (
@@ -63,7 +63,7 @@ class _BaseClient(ABC):
         # API key is optional - allow None for local-only usage
         try:
             self.api_key = api_key or default_api_key()
-        except (voyageai.error.AuthenticationError, OSError):
+        except (AuthenticationError, OSError):
             # No usable API key - that's OK for local models. OSError covers a
             # set-but-stale VOYAGE_API_KEY_PATH pointing at an unreadable file
             # (default_api_key() opens it, raising FileNotFoundError/OSError),
@@ -91,7 +91,7 @@ class _BaseClient(ABC):
         the request layer with a less actionable error.
         """
         if not self.api_key:
-            raise voyageai.error.AuthenticationError(
+            raise AuthenticationError(
                 "An API key is required for API-based models. "
                 "Set your API key via the VOYAGE_API_KEY environment variable or "
                 "pass it to the client (api_key=...)."

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -46,7 +46,7 @@ class _BaseClient(ABC):
     """Voyage AI Client
 
     Args:
-        api_key (str): Your API key.
+        api_key (str): Your API key (optional for local models).
         max_retries (int): Maximum number of retries if API call fails.
         timeout (float): Timeout in seconds.
         base_url (str): Base URL for the API endpoint.
@@ -59,9 +59,18 @@ class _BaseClient(ABC):
         timeout: Optional[float] = None,
         base_url: Optional[str] = None,
     ) -> None:
-        self.api_key = api_key or default_api_key()
+        # API key is optional - allow None for local-only usage
+        try:
+            self.api_key = api_key or default_api_key()
+        except voyageai.error.AuthenticationError:
+            # No API key available - that's OK for local models
+            self.api_key = None
+
         self.max_retries = max_retries
-        base_url = base_url or get_default_base_url(self.api_key)
+
+        # Only set base_url if we have an API key
+        if self.api_key:
+            base_url = base_url or get_default_base_url(self.api_key)
 
         self._params = {
             "api_key": self.api_key,

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -63,11 +63,12 @@ class _BaseClient(ABC):
         # API key is optional - allow None for local-only usage
         try:
             self.api_key = api_key or default_api_key()
-        except (AuthenticationError, OSError):
-            # No usable API key - that's OK for local models. OSError covers a
-            # set-but-stale VOYAGE_API_KEY_PATH pointing at an unreadable file
-            # (default_api_key() opens it, raising FileNotFoundError/OSError),
-            # which should fall back to keyless rather than break construction.
+        except (AuthenticationError, OSError, UnicodeDecodeError):
+            # No usable API key - that's OK for local models. A set-but-stale
+            # VOYAGE_API_KEY_PATH is tolerated: default_api_key() opens it in
+            # text mode, so a missing/unreadable file raises OSError and a
+            # non-UTF-8 (e.g. binary) file raises UnicodeDecodeError. Both should
+            # fall back to keyless rather than break construction.
             self.api_key = None
 
         self.max_retries = max_retries

--- a/voyageai/_base.py
+++ b/voyageai/_base.py
@@ -62,8 +62,11 @@ class _BaseClient(ABC):
         # API key is optional - allow None for local-only usage
         try:
             self.api_key = api_key or default_api_key()
-        except voyageai.error.AuthenticationError:
-            # No API key available - that's OK for local models
+        except (voyageai.error.AuthenticationError, OSError):
+            # No usable API key - that's OK for local models. OSError covers a
+            # set-but-stale VOYAGE_API_KEY_PATH pointing at an unreadable file
+            # (default_api_key() opens it, raising FileNotFoundError/OSError),
+            # which should fall back to keyless rather than break construction.
             self.api_key = None
 
         self.max_retries = max_retries

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -88,11 +88,7 @@ class Client(_BaseClient):
             )
 
         # API models require an API key
-        if not self.api_key:
-            raise error.AuthenticationError(
-                "An API key is required for API-based models. "
-                "Set your API key via VOYAGE_API_KEY environment variable or pass it to Client(api_key=...)."
-            )
+        self._require_api_key()
 
         response = None
         for attempt in self._make_retry_controller():
@@ -125,6 +121,8 @@ class Client(_BaseClient):
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
+        self._require_api_key()
+
         normalized_inputs, extra_kwargs = validate_and_normalize_contextualized_inputs(
             inputs=inputs,
             input_type=input_type,
@@ -169,6 +167,8 @@ class Client(_BaseClient):
         top_k: Optional[int] = None,
         truncation: bool = True,
     ) -> RerankingObject:
+        self._require_api_key()
+
         response = None
         for attempt in self._make_retry_controller():
             with attempt:
@@ -196,6 +196,8 @@ class Client(_BaseClient):
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
     ) -> MultimodalEmbeddingsObject:
+        self._require_api_key()
+
         response = None
         for attempt in self._make_retry_controller():
             with attempt:

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 from PIL.Image import Image
 from tenacity import (
@@ -16,6 +16,7 @@ from voyageai.chunking import (
     apply_chunking,
     validate_and_normalize_contextualized_inputs,
 )
+from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
 from voyageai.object import (
     ContextualizedEmbeddingsObject,
     EmbeddingsObject,
@@ -25,12 +26,15 @@ from voyageai.object import (
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest
 from voyageai.video_utils import Video
 
+if TYPE_CHECKING:
+    from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
 
 class Client(_BaseClient):
     """Voyage AI Client
 
     Args:
-        api_key (str): Your API key.
+        api_key (str): Your API key (not required for local models).
         max_retries (int): Maximum number of retries if API call fails.
         timeout (float): Timeout in seconds.
         base_url (str): Base URL for the API endpoint.
@@ -44,6 +48,7 @@ class Client(_BaseClient):
         base_url: Optional[str] = None,
     ) -> None:
         super().__init__(api_key, max_retries, timeout, base_url)
+        self._local_backends: Dict[str, "SentenceTransformerBackend"] = {}
 
     def _make_retry_controller(self) -> Retrying:
         return Retrying(
@@ -56,6 +61,42 @@ class Client(_BaseClient):
                 | retry_if_exception_type(error.Timeout)
             ),
         )
+
+    def _get_local_backend(self, model: str) -> "SentenceTransformerBackend":
+        """Get or create a local backend for the given model."""
+        if model not in self._local_backends:
+            from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+            self._local_backends[model] = SentenceTransformerBackend(model)
+        return self._local_backends[model]
+
+    def _embed_local(
+        self,
+        texts: List[str],
+        model: str,
+        input_type: Optional[str] = None,
+        truncation: bool = True,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+    ) -> EmbeddingsObject:
+        """Generate embeddings using a local model."""
+        backend = self._get_local_backend(model)
+
+        embeddings_array = backend.encode(
+            texts=texts,
+            input_type=input_type,
+            output_dtype=output_dtype,
+            output_dimension=output_dimension,
+            truncation=truncation,
+        )
+
+        total_tokens = backend.count_tokens(texts)
+
+        result = EmbeddingsObject()
+        result.embeddings = embeddings_array.tolist()
+        result.total_tokens = total_tokens
+
+        return result
 
     def embed(
         self,
@@ -73,6 +114,24 @@ class Client(_BaseClient):
                 "It will be a required argument in the future. We recommend to specify the model when using this "
                 "function. Please see https://docs.voyageai.com/docs/embeddings for the list of latest models "
                 "provided by Voyage AI."
+            )
+
+        # Check if this is a local model
+        if model in LOCAL_MODELS:
+            return self._embed_local(
+                texts=texts,
+                model=model,
+                input_type=input_type,
+                truncation=truncation,
+                output_dtype=output_dtype,
+                output_dimension=output_dimension,
+            )
+
+        # API models require an API key
+        if not self.api_key:
+            raise error.AuthenticationError(
+                "An API key is required for API-based models. "
+                "Set your API key via VOYAGE_API_KEY environment variable or pass it to Client(api_key=...)."
             )
 
         response = None

--- a/voyageai/client.py
+++ b/voyageai/client.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from PIL.Image import Image
 from tenacity import (
@@ -16,7 +16,7 @@ from voyageai.chunking import (
     apply_chunking,
     validate_and_normalize_contextualized_inputs,
 )
-from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
+from voyageai.local.helpers import embed_local, is_local_model
 from voyageai.object import (
     ContextualizedEmbeddingsObject,
     EmbeddingsObject,
@@ -25,9 +25,6 @@ from voyageai.object import (
 )
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest
 from voyageai.video_utils import Video
-
-if TYPE_CHECKING:
-    from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
 
 
 class Client(_BaseClient):
@@ -48,7 +45,6 @@ class Client(_BaseClient):
         base_url: Optional[str] = None,
     ) -> None:
         super().__init__(api_key, max_retries, timeout, base_url)
-        self._local_backends: Dict[str, "SentenceTransformerBackend"] = {}
 
     def _make_retry_controller(self) -> Retrying:
         return Retrying(
@@ -61,42 +57,6 @@ class Client(_BaseClient):
                 | retry_if_exception_type(error.Timeout)
             ),
         )
-
-    def _get_local_backend(self, model: str) -> "SentenceTransformerBackend":
-        """Get or create a local backend for the given model."""
-        if model not in self._local_backends:
-            from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
-
-            self._local_backends[model] = SentenceTransformerBackend(model)
-        return self._local_backends[model]
-
-    def _embed_local(
-        self,
-        texts: List[str],
-        model: str,
-        input_type: Optional[str] = None,
-        truncation: bool = True,
-        output_dtype: Optional[str] = None,
-        output_dimension: Optional[int] = None,
-    ) -> EmbeddingsObject:
-        """Generate embeddings using a local model."""
-        backend = self._get_local_backend(model)
-
-        embeddings_array = backend.encode(
-            texts=texts,
-            input_type=input_type,
-            output_dtype=output_dtype,
-            output_dimension=output_dimension,
-            truncation=truncation,
-        )
-
-        total_tokens = backend.count_tokens(texts)
-
-        result = EmbeddingsObject()
-        result.embeddings = embeddings_array.tolist()
-        result.total_tokens = total_tokens
-
-        return result
 
     def embed(
         self,
@@ -117,8 +77,8 @@ class Client(_BaseClient):
             )
 
         # Check if this is a local model
-        if model in LOCAL_MODELS:
-            return self._embed_local(
+        if is_local_model(model):
+            return embed_local(
                 texts=texts,
                 model=model,
                 input_type=input_type,

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -1,6 +1,6 @@
 import asyncio
 import warnings
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from PIL.Image import Image
 from tenacity import (
@@ -17,7 +17,7 @@ from voyageai.chunking import (
     apply_chunking,
     validate_and_normalize_contextualized_inputs,
 )
-from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
+from voyageai.local.helpers import embed_local, is_local_model
 from voyageai.object import (
     ContextualizedEmbeddingsObject,
     EmbeddingsObject,
@@ -26,9 +26,6 @@ from voyageai.object import (
 )
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest
 from voyageai.video_utils import Video
-
-if TYPE_CHECKING:
-    from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
 
 
 class AsyncClient(_BaseClient):
@@ -49,7 +46,6 @@ class AsyncClient(_BaseClient):
         base_url: Optional[str] = None,
     ) -> None:
         super().__init__(api_key, max_retries, timeout, base_url)
-        self._local_backends: Dict[str, "SentenceTransformerBackend"] = {}
 
     def _make_retry_controller(self) -> AsyncRetrying:
         return AsyncRetrying(
@@ -61,62 +57,6 @@ class AsyncClient(_BaseClient):
                 | retry_if_exception_type(error.ServiceUnavailableError)
                 | retry_if_exception_type(error.Timeout)
             ),
-        )
-
-    def _get_local_backend(self, model: str) -> "SentenceTransformerBackend":
-        """Get or create a local backend for the given model."""
-        if model not in self._local_backends:
-            from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
-
-            self._local_backends[model] = SentenceTransformerBackend(model)
-        return self._local_backends[model]
-
-    def _embed_local_sync(
-        self,
-        texts: List[str],
-        model: str,
-        input_type: Optional[str] = None,
-        truncation: bool = True,
-        output_dtype: Optional[str] = None,
-        output_dimension: Optional[int] = None,
-    ) -> EmbeddingsObject:
-        """Generate embeddings using a local model (sync, for use with to_thread)."""
-        backend = self._get_local_backend(model)
-
-        embeddings_array = backend.encode(
-            texts=texts,
-            input_type=input_type,
-            output_dtype=output_dtype,
-            output_dimension=output_dimension,
-            truncation=truncation,
-        )
-
-        total_tokens = backend.count_tokens(texts)
-
-        result = EmbeddingsObject()
-        result.embeddings = embeddings_array.tolist()
-        result.total_tokens = total_tokens
-
-        return result
-
-    async def _embed_local(
-        self,
-        texts: List[str],
-        model: str,
-        input_type: Optional[str] = None,
-        truncation: bool = True,
-        output_dtype: Optional[str] = None,
-        output_dimension: Optional[int] = None,
-    ) -> EmbeddingsObject:
-        """Generate embeddings using a local model (async)."""
-        return await asyncio.to_thread(
-            self._embed_local_sync,
-            texts=texts,
-            model=model,
-            input_type=input_type,
-            truncation=truncation,
-            output_dtype=output_dtype,
-            output_dimension=output_dimension,
         )
 
     async def embed(
@@ -138,8 +78,9 @@ class AsyncClient(_BaseClient):
             )
 
         # Check if this is a local model
-        if model in LOCAL_MODELS:
-            return await self._embed_local(
+        if is_local_model(model):
+            return await asyncio.to_thread(
+                embed_local,
                 texts=texts,
                 model=model,
                 input_type=input_type,

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -1,5 +1,6 @@
+import asyncio
 import warnings
-from typing import Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 from PIL.Image import Image
 from tenacity import (
@@ -16,6 +17,7 @@ from voyageai.chunking import (
     apply_chunking,
     validate_and_normalize_contextualized_inputs,
 )
+from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
 from voyageai.object import (
     ContextualizedEmbeddingsObject,
     EmbeddingsObject,
@@ -25,12 +27,15 @@ from voyageai.object import (
 from voyageai.object.multimodal_embeddings import MultimodalInputRequest
 from voyageai.video_utils import Video
 
+if TYPE_CHECKING:
+    from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
 
 class AsyncClient(_BaseClient):
     """Voyage AI Async Client
 
     Args:
-        api_key (str): Your API key.
+        api_key (str): Your API key (not required for local models).
         max_retries (int): Maximum number of retries if API call fails.
         timeout (float): Timeout in seconds.
         base_url (str): Base URL for the API endpoint.
@@ -44,6 +49,7 @@ class AsyncClient(_BaseClient):
         base_url: Optional[str] = None,
     ) -> None:
         super().__init__(api_key, max_retries, timeout, base_url)
+        self._local_backends: Dict[str, "SentenceTransformerBackend"] = {}
 
     def _make_retry_controller(self) -> AsyncRetrying:
         return AsyncRetrying(
@@ -55,6 +61,62 @@ class AsyncClient(_BaseClient):
                 | retry_if_exception_type(error.ServiceUnavailableError)
                 | retry_if_exception_type(error.Timeout)
             ),
+        )
+
+    def _get_local_backend(self, model: str) -> "SentenceTransformerBackend":
+        """Get or create a local backend for the given model."""
+        if model not in self._local_backends:
+            from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+            self._local_backends[model] = SentenceTransformerBackend(model)
+        return self._local_backends[model]
+
+    def _embed_local_sync(
+        self,
+        texts: List[str],
+        model: str,
+        input_type: Optional[str] = None,
+        truncation: bool = True,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+    ) -> EmbeddingsObject:
+        """Generate embeddings using a local model (sync, for use with to_thread)."""
+        backend = self._get_local_backend(model)
+
+        embeddings_array = backend.encode(
+            texts=texts,
+            input_type=input_type,
+            output_dtype=output_dtype,
+            output_dimension=output_dimension,
+            truncation=truncation,
+        )
+
+        total_tokens = backend.count_tokens(texts)
+
+        result = EmbeddingsObject()
+        result.embeddings = embeddings_array.tolist()
+        result.total_tokens = total_tokens
+
+        return result
+
+    async def _embed_local(
+        self,
+        texts: List[str],
+        model: str,
+        input_type: Optional[str] = None,
+        truncation: bool = True,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+    ) -> EmbeddingsObject:
+        """Generate embeddings using a local model (async)."""
+        return await asyncio.to_thread(
+            self._embed_local_sync,
+            texts=texts,
+            model=model,
+            input_type=input_type,
+            truncation=truncation,
+            output_dtype=output_dtype,
+            output_dimension=output_dimension,
         )
 
     async def embed(
@@ -73,6 +135,24 @@ class AsyncClient(_BaseClient):
                 "It will be a required argument in the future. We recommend to specify the model when using this "
                 "function. Please see https://docs.voyageai.com/docs/embeddings for the list of latest models "
                 "provided by Voyage AI."
+            )
+
+        # Check if this is a local model
+        if model in LOCAL_MODELS:
+            return await self._embed_local(
+                texts=texts,
+                model=model,
+                input_type=input_type,
+                truncation=truncation,
+                output_dtype=output_dtype,
+                output_dimension=output_dimension,
+            )
+
+        # API models require an API key
+        if not self.api_key:
+            raise error.AuthenticationError(
+                "An API key is required for API-based models. "
+                "Set your API key via VOYAGE_API_KEY environment variable or pass it to AsyncClient(api_key=...)."
             )
 
         response = None

--- a/voyageai/client_async.py
+++ b/voyageai/client_async.py
@@ -90,11 +90,7 @@ class AsyncClient(_BaseClient):
             )
 
         # API models require an API key
-        if not self.api_key:
-            raise error.AuthenticationError(
-                "An API key is required for API-based models. "
-                "Set your API key via VOYAGE_API_KEY environment variable or pass it to AsyncClient(api_key=...)."
-            )
+        self._require_api_key()
 
         response = None
         async for attempt in self._make_retry_controller():
@@ -127,6 +123,8 @@ class AsyncClient(_BaseClient):
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
     ) -> ContextualizedEmbeddingsObject:
+        self._require_api_key()
+
         normalized_inputs, extra_kwargs = validate_and_normalize_contextualized_inputs(
             inputs=inputs,
             input_type=input_type,
@@ -171,6 +169,8 @@ class AsyncClient(_BaseClient):
         top_k: Optional[int] = None,
         truncation: bool = True,
     ) -> RerankingObject:
+        self._require_api_key()
+
         response = None
         async for attempt in self._make_retry_controller():
             with attempt:
@@ -198,6 +198,8 @@ class AsyncClient(_BaseClient):
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
     ) -> MultimodalEmbeddingsObject:
+        self._require_api_key()
+
         response = None
         async for attempt in self._make_retry_controller():
             with attempt:

--- a/voyageai/local/__init__.py
+++ b/voyageai/local/__init__.py
@@ -1,0 +1,30 @@
+"""Local model support for Voyage AI SDK.
+
+This module provides lazy imports to avoid loading torch/sentence-transformers
+for API-only users. Install with: pip install voyageai[local]
+"""
+
+# Lazy imports - set to None if not available
+try:
+    import sentence_transformers as _sentence_transformers
+    import torch as _torch
+except ImportError:  # pragma: no cover - handled lazily in functions
+    _sentence_transformers = None  # type: ignore[assignment]
+    _torch = None  # type: ignore[assignment]
+
+
+def _ensure_local_deps() -> tuple:
+    """Ensure local model dependencies are available.
+
+    Returns:
+        Tuple of (sentence_transformers, torch) modules.
+
+    Raises:
+        ImportError: If sentence-transformers or torch are not installed.
+    """
+    if _sentence_transformers is None or _torch is None:
+        raise ImportError(
+            "The 'sentence-transformers' and 'torch' packages are required for local models. "
+            "Install them with: pip install voyageai[local]"
+        )
+    return _sentence_transformers, _torch

--- a/voyageai/local/__init__.py
+++ b/voyageai/local/__init__.py
@@ -4,13 +4,7 @@ This module provides lazy imports to avoid loading torch/sentence-transformers
 for API-only users. Install with: pip install voyageai[local]
 """
 
-# Lazy imports - set to None if not available
-try:
-    import sentence_transformers as _sentence_transformers
-    import torch as _torch
-except ImportError:  # pragma: no cover - handled lazily in functions
-    _sentence_transformers = None  # type: ignore[assignment]
-    _torch = None  # type: ignore[assignment]
+import sys
 
 
 def _ensure_local_deps() -> tuple:
@@ -22,9 +16,29 @@ def _ensure_local_deps() -> tuple:
     Raises:
         ImportError: If sentence-transformers or torch are not installed.
     """
-    if _sentence_transformers is None or _torch is None:
+    if sys.version_info < (3, 10):
+        raise ImportError(
+            "Local model support requires Python 3.10 or later. "
+            "You are running Python {}.{}. Please use an API-based model or upgrade Python.".format(
+                sys.version_info.major, sys.version_info.minor
+            )
+        )
+    try:
+        import sentence_transformers
+        import torch
+
+        return sentence_transformers, torch
+    except ImportError:
         raise ImportError(
             "The 'sentence-transformers' and 'torch' packages are required for local models. "
             "Install them with: pip install voyageai[local]"
         )
-    return _sentence_transformers, _torch
+
+
+def _is_local_available() -> bool:
+    """Check if sentence-transformers and torch are installed (lazy check)."""
+    try:
+        _ensure_local_deps()
+        return True
+    except ImportError:
+        return False

--- a/voyageai/local/helpers.py
+++ b/voyageai/local/helpers.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, List, Optional
 
+from voyageai.error import InvalidRequestError
 from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
 from voyageai.object import EmbeddingsObject
 
@@ -54,6 +55,12 @@ def embed_local(
     # this, encode() would return a 1-D array and embeddings[0] would be a float.
     if isinstance(texts, str):
         texts = [texts]
+
+    # The hosted API rejects empty input; match it so both paths raise the same
+    # error. This also rejects None (``not None`` is True), which would otherwise
+    # crash downstream in encode()/count_tokens() with a TypeError.
+    if not texts:
+        raise InvalidRequestError("inputs must not be empty.")
 
     backend = get_local_backend(model)
 

--- a/voyageai/local/helpers.py
+++ b/voyageai/local/helpers.py
@@ -62,6 +62,16 @@ def embed_local(
     if not texts:
         raise InvalidRequestError("inputs must not be empty.")
 
+    # The hosted API caps the input list (see docs / tests/test_client.py::
+    # test_client_embed_batch_size). Enforce the same limit here, before loading
+    # the model, so an oversized batch raises the same error on both paths.
+    max_batch_size = LOCAL_MODELS[model].max_batch_size
+    if len(texts) > max_batch_size:
+        raise InvalidRequestError(
+            f"The number of inputs ({len(texts)}) exceeds the maximum "
+            f"batch size of {max_batch_size}."
+        )
+
     backend = get_local_backend(model)
 
     embeddings_array, total_tokens = backend.encode(

--- a/voyageai/local/helpers.py
+++ b/voyageai/local/helpers.py
@@ -1,0 +1,69 @@
+"""Shared helpers for local model routing in sync and async clients."""
+
+from typing import TYPE_CHECKING, List, Optional
+
+from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
+from voyageai.object import EmbeddingsObject
+
+if TYPE_CHECKING:
+    from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+
+def get_local_backend(model: str) -> "SentenceTransformerBackend":
+    """Create a local backend for the given model.
+
+    Uses the global ModelCache singleton for caching, so no per-client cache
+    is needed.
+
+    Args:
+        model: Model name (must be in LOCAL_MODELS).
+
+    Returns:
+        SentenceTransformerBackend instance (cached via ModelCache singleton).
+    """
+    from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
+
+    return SentenceTransformerBackend(model)
+
+
+def embed_local(
+    texts: List[str],
+    model: str,
+    input_type: Optional[str] = None,
+    truncation: bool = True,
+    output_dtype: Optional[str] = None,
+    output_dimension: Optional[int] = None,
+) -> EmbeddingsObject:
+    """Generate embeddings using a local model.
+
+    Args:
+        texts: List of texts to embed.
+        model: Model name.
+        input_type: "query", "document", or None.
+        truncation: Whether to truncate texts exceeding max tokens.
+        output_dtype: Output data type.
+        output_dimension: Output embedding dimension.
+
+    Returns:
+        EmbeddingsObject with embeddings and token count.
+    """
+    backend = get_local_backend(model)
+
+    embeddings_array, total_tokens = backend.encode(
+        texts=texts,
+        input_type=input_type,
+        output_dtype=output_dtype,
+        output_dimension=output_dimension,
+        truncation=truncation,
+    )
+
+    result = EmbeddingsObject()
+    result.embeddings = embeddings_array.tolist()
+    result.total_tokens = total_tokens
+
+    return result
+
+
+def is_local_model(model: str) -> bool:
+    """Check if a model name refers to a locally-supported model."""
+    return model in LOCAL_MODELS

--- a/voyageai/local/helpers.py
+++ b/voyageai/local/helpers.py
@@ -47,6 +47,12 @@ def embed_local(
     Returns:
         EmbeddingsObject with embeddings and token count.
     """
+    # The API path accepts a bare string and returns a list with one embedding
+    # (embeddings == [[...]]). Normalize here so the local path matches; without
+    # this, encode() would return a 1-D array and embeddings[0] would be a float.
+    if isinstance(texts, str):
+        texts = [texts]
+
     backend = get_local_backend(model)
 
     embeddings_array, total_tokens = backend.encode(

--- a/voyageai/local/helpers.py
+++ b/voyageai/local/helpers.py
@@ -1,6 +1,6 @@
 """Shared helpers for local model routing in sync and async clients."""
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from voyageai.error import InvalidRequestError
 from voyageai.local.model_registry import SUPPORTED_MODELS as LOCAL_MODELS
@@ -30,7 +30,7 @@ def get_local_backend(model: str) -> "SentenceTransformerBackend":
 
 
 def embed_local(
-    texts: List[str],
+    texts: Union[str, List[str]],
     model: str,
     input_type: Optional[str] = None,
     truncation: bool = True,
@@ -40,7 +40,8 @@ def embed_local(
     """Generate embeddings using a local model.
 
     Args:
-        texts: List of texts to embed.
+        texts: A single string or a list of strings to embed. A bare string is
+            normalized to a one-element list (matching the hosted API).
         model: Model name.
         input_type: "query", "document", or None.
         truncation: Whether to truncate texts exceeding max tokens.

--- a/voyageai/local/helpers.py
+++ b/voyageai/local/helpers.py
@@ -12,14 +12,16 @@ if TYPE_CHECKING:
 def get_local_backend(model: str) -> "SentenceTransformerBackend":
     """Create a local backend for the given model.
 
-    Uses the global ModelCache singleton for caching, so no per-client cache
-    is needed.
+    A fresh SentenceTransformerBackend wrapper is constructed on every call;
+    only the heavy underlying SentenceTransformer model is cached (process-wide,
+    keyed by model:device, via the ModelCache singleton). The per-call wrapper
+    cost is small, so no per-client backend cache is needed.
 
     Args:
         model: Model name (must be in LOCAL_MODELS).
 
     Returns:
-        SentenceTransformerBackend instance (cached via ModelCache singleton).
+        A SentenceTransformerBackend wrapping the cached model.
     """
     from voyageai.local.sentence_transformer_backend import SentenceTransformerBackend
 

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -2,7 +2,7 @@
 
 import threading
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from voyageai.error import InvalidRequestError
 
@@ -112,9 +112,15 @@ class ModelCache:
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._cache: Dict[str, Any] = {}
-                    cls._instance._cache_lock = threading.Lock()
+                    # Fully initialize a local instance, then publish it last.
+                    # The outer ``if cls._instance is None`` runs without the
+                    # lock, so a concurrent caller must never be able to observe
+                    # a published-but-half-built instance (one missing _cache /
+                    # _cache_lock) and crash dereferencing them.
+                    instance = super().__new__(cls)
+                    instance._cache = {}
+                    instance._cache_lock = threading.Lock()
+                    cls._instance = instance
         return cls._instance
 
     def get(self, key: str) -> Optional[Any]:
@@ -144,7 +150,7 @@ class ModelCache:
         with self._cache_lock:
             self._cache.clear()
 
-    def get_or_load(self, key: str, loader: callable) -> Any:
+    def get_or_load(self, key: str, loader: Callable[[], Any]) -> Any:
         """Get a cached model or load it if not cached.
 
         Thread-safe: holds the lock for the full check-load-store sequence.

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -1,0 +1,154 @@
+"""Model configuration and thread-safe caching for local models."""
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class LocalModelConfig:
+    """Configuration for a local embedding model."""
+
+    huggingface_id: str
+    max_tokens: int
+    default_dimension: int
+    supported_dimensions: tuple
+    supported_precisions: tuple
+    trust_remote_code: bool = True
+
+    def validate_dimension(self, dimension: Optional[int]) -> int:
+        """Validate and return the dimension to use.
+
+        Args:
+            dimension: Requested dimension, or None for default.
+
+        Returns:
+            The dimension to use.
+
+        Raises:
+            ValueError: If dimension is not supported.
+        """
+        if dimension is None:
+            return self.default_dimension
+        if dimension not in self.supported_dimensions:
+            raise ValueError(
+                f"Invalid output_dimension {dimension}. "
+                f"Supported dimensions: {self.supported_dimensions}"
+            )
+        return dimension
+
+    def validate_precision(self, precision: Optional[str]) -> Optional[str]:
+        """Validate and return the precision to use.
+
+        Args:
+            precision: Requested precision, or None for default (float32).
+
+        Returns:
+            The precision to use.
+
+        Raises:
+            ValueError: If precision is not supported.
+        """
+        if precision is None:
+            return None
+        if precision not in self.supported_precisions:
+            raise ValueError(
+                f"Invalid output_dtype '{precision}'. "
+                f"Supported dtypes: {self.supported_precisions}"
+            )
+        return precision
+
+
+# Supported local models
+SUPPORTED_MODELS: Dict[str, LocalModelConfig] = {
+    "voyage-4-nano": LocalModelConfig(
+        huggingface_id="voyageai/voyage-4-nano",
+        max_tokens=32768,
+        default_dimension=2048,
+        supported_dimensions=(2048, 1024, 512, 256),
+        supported_precisions=("float32", "int8", "uint8", "binary", "ubinary"),
+        trust_remote_code=True,
+    ),
+}
+
+
+def get_model_config(model: str) -> LocalModelConfig:
+    """Get configuration for a model.
+
+    Args:
+        model: Model name.
+
+    Returns:
+        LocalModelConfig for the model.
+
+    Raises:
+        ValueError: If model is not supported.
+    """
+    if model not in SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unsupported local model '{model}'. "
+            f"Supported models: {list(SUPPORTED_MODELS.keys())}"
+        )
+    return SUPPORTED_MODELS[model]
+
+
+class ModelCache:
+    """Thread-safe singleton cache for loaded models.
+
+    Avoids reloading models per call, which can be expensive.
+    """
+
+    _instance: Optional["ModelCache"] = None
+    _lock: threading.Lock = threading.Lock()
+
+    def __new__(cls) -> "ModelCache":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._cache: Dict[str, Any] = {}
+                    cls._instance._cache_lock = threading.Lock()
+        return cls._instance
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get a cached model.
+
+        Args:
+            key: Cache key (typically model name + device).
+
+        Returns:
+            Cached model or None if not found.
+        """
+        with self._cache_lock:
+            return self._cache.get(key)
+
+    def set(self, key: str, model: Any) -> None:
+        """Cache a model.
+
+        Args:
+            key: Cache key.
+            model: Model to cache.
+        """
+        with self._cache_lock:
+            self._cache[key] = model
+
+    def clear(self) -> None:
+        """Clear all cached models."""
+        with self._cache_lock:
+            self._cache.clear()
+
+    def get_or_load(self, key: str, loader: callable) -> Any:
+        """Get a cached model or load it if not cached.
+
+        Args:
+            key: Cache key.
+            loader: Callable to load the model if not cached.
+
+        Returns:
+            The cached or newly loaded model.
+        """
+        model = self.get(key)
+        if model is None:
+            model = loader()
+            self.set(key, model)
+        return model

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -66,7 +66,7 @@ SUPPORTED_MODELS: Dict[str, LocalModelConfig] = {
         max_tokens=32768,
         default_dimension=2048,
         supported_dimensions=(2048, 1024, 512, 256),
-        supported_precisions=("float32", "int8", "uint8", "binary", "ubinary"),
+        supported_precisions=("float32", "float", "int8", "uint8", "binary", "ubinary"),
         trust_remote_code=True,
     ),
 }
@@ -140,6 +140,8 @@ class ModelCache:
     def get_or_load(self, key: str, loader: callable) -> Any:
         """Get a cached model or load it if not cached.
 
+        Thread-safe: holds the lock for the full check-load-store sequence.
+
         Args:
             key: Cache key.
             loader: Callable to load the model if not cached.
@@ -147,8 +149,9 @@ class ModelCache:
         Returns:
             The cached or newly loaded model.
         """
-        model = self.get(key)
-        if model is None:
-            model = loader()
-            self.set(key, model)
-        return model
+        with self._cache_lock:
+            model = self._cache.get(key)
+            if model is None:
+                model = loader()
+                self._cache[key] = model
+            return model

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -17,6 +17,9 @@ class LocalModelConfig:
     supported_dimensions: tuple
     supported_precisions: tuple
     trust_remote_code: bool = True
+    # Max inputs per embed() call. Matches the hosted API's documented list limit
+    # so the same call raises InvalidRequestError on both the API and local paths.
+    max_batch_size: int = 1000
 
     def validate_dimension(self, dimension: Optional[int]) -> int:
         """Validate and return the dimension to use.
@@ -75,6 +78,7 @@ SUPPORTED_MODELS: Dict[str, LocalModelConfig] = {
         # sentence_transformer_backend.py).
         supported_precisions=("float32", "float", "binary", "ubinary"),
         trust_remote_code=True,
+        max_batch_size=1000,
     ),
 }
 

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -66,7 +66,10 @@ SUPPORTED_MODELS: Dict[str, LocalModelConfig] = {
         max_tokens=32768,
         default_dimension=2048,
         supported_dimensions=(2048, 1024, 512, 256),
-        supported_precisions=("float32", "float", "int8", "uint8", "binary", "ubinary"),
+        # int8/uint8 omitted: they require fixed calibration ranges to match the
+        # hosted API, which we don't ship locally yet (see encode() in
+        # sentence_transformer_backend.py).
+        supported_precisions=("float32", "float", "binary", "ubinary"),
         trust_remote_code=True,
     ),
 }

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -4,6 +4,8 @@ import threading
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from voyageai.error import InvalidRequestError
+
 
 @dataclass(frozen=True)
 class LocalModelConfig:
@@ -26,12 +28,13 @@ class LocalModelConfig:
             The dimension to use.
 
         Raises:
-            ValueError: If dimension is not supported.
+            InvalidRequestError: If dimension is not supported. Matches the
+                hosted API, which rejects invalid output_dimension the same way.
         """
         if dimension is None:
             return self.default_dimension
         if dimension not in self.supported_dimensions:
-            raise ValueError(
+            raise InvalidRequestError(
                 f"Invalid output_dimension {dimension}. "
                 f"Supported dimensions: {self.supported_dimensions}"
             )
@@ -47,12 +50,13 @@ class LocalModelConfig:
             The precision to use.
 
         Raises:
-            ValueError: If precision is not supported.
+            InvalidRequestError: If precision is not supported. Matches the
+                hosted API, which rejects invalid output_dtype the same way.
         """
         if precision is None:
             return None
         if precision not in self.supported_precisions:
-            raise ValueError(
+            raise InvalidRequestError(
                 f"Invalid output_dtype '{precision}'. "
                 f"Supported dtypes: {self.supported_precisions}"
             )

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -6,6 +6,12 @@ from typing import Any, Callable, Dict, Optional
 
 from voyageai.error import InvalidRequestError
 
+# Maximum inputs per embed() call, matching the hosted API's documented list
+# limit (https://docs.voyageai.com/docs/embeddings) so an oversized batch raises
+# the same InvalidRequestError on both the API and local paths. Single source of
+# truth for the default LocalModelConfig.max_batch_size below.
+HOSTED_MAX_BATCH_SIZE = 1000
+
 
 @dataclass(frozen=True)
 class LocalModelConfig:
@@ -17,9 +23,8 @@ class LocalModelConfig:
     supported_dimensions: tuple
     supported_precisions: tuple
     trust_remote_code: bool = True
-    # Max inputs per embed() call. Matches the hosted API's documented list limit
-    # so the same call raises InvalidRequestError on both the API and local paths.
-    max_batch_size: int = 1000
+    # Max inputs per embed() call; see HOSTED_MAX_BATCH_SIZE.
+    max_batch_size: int = HOSTED_MAX_BATCH_SIZE
 
     def validate_dimension(self, dimension: Optional[int]) -> int:
         """Validate and return the dimension to use.
@@ -78,7 +83,7 @@ SUPPORTED_MODELS: Dict[str, LocalModelConfig] = {
         # sentence_transformer_backend.py).
         supported_precisions=("float32", "float", "binary", "ubinary"),
         trust_remote_code=True,
-        max_batch_size=1000,
+        # max_batch_size defaults to HOSTED_MAX_BATCH_SIZE (see LocalModelConfig).
     ),
 }
 

--- a/voyageai/local/model_registry.py
+++ b/voyageai/local/model_registry.py
@@ -120,8 +120,24 @@ class ModelCache:
                     instance = super().__new__(cls)
                     instance._cache = {}
                     instance._cache_lock = threading.Lock()
+                    # Per-cache-key locks. ``_load_locks`` serialize cold loads
+                    # of a given key (so loading one model never blocks callers
+                    # of a different, already-cached model); ``_inference_locks``
+                    # serialize forward passes on a given cached model
+                    # (SentenceTransformer.encode* is not thread-safe).
+                    instance._load_locks = {}
+                    instance._inference_locks = {}
                     cls._instance = instance
         return cls._instance
+
+    def _keyed_lock(self, registry: Dict[str, threading.Lock], key: str) -> threading.Lock:
+        """Return a lock for ``key`` from ``registry``, creating it if needed."""
+        with self._cache_lock:
+            lock = registry.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                registry[key] = lock
+            return lock
 
     def get(self, key: str) -> Optional[Any]:
         """Get a cached model.
@@ -150,10 +166,22 @@ class ModelCache:
         with self._cache_lock:
             self._cache.clear()
 
+    def get_inference_lock(self, key: str) -> threading.Lock:
+        """Return the per-key lock guarding inference on the cached model.
+
+        ``SentenceTransformer.encode*`` is not contractually thread-safe, so
+        concurrent embeds that share one cached model (e.g. the async path
+        dispatching to worker threads) must serialize their forward passes.
+        """
+        return self._keyed_lock(self._inference_locks, key)
+
     def get_or_load(self, key: str, loader: Callable[[], Any]) -> Any:
         """Get a cached model or load it if not cached.
 
-        Thread-safe: holds the lock for the full check-load-store sequence.
+        Uses a per-key load lock so only concurrent loads of the *same* key
+        serialize: a multi-second cold load of one model never blocks callers
+        requesting a different, already-cached model. (Holding the single cache
+        lock across the whole load would serialize unrelated keys.)
 
         Args:
             key: Cache key.
@@ -162,9 +190,14 @@ class ModelCache:
         Returns:
             The cached or newly loaded model.
         """
-        with self._cache_lock:
-            model = self._cache.get(key)
+        model = self.get(key)
+        if model is not None:
+            return model
+        with self._keyed_lock(self._load_locks, key):
+            # Re-check under the per-key lock: another thread may have finished
+            # loading this key while we waited.
+            model = self.get(key)
             if model is None:
                 model = loader()
-                self._cache[key] = model
+                self.set(key, model)
             return model

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -1,0 +1,125 @@
+"""Sentence-transformers backend for local model inference."""
+
+from typing import List, Optional
+
+import numpy as np
+
+from voyageai.local import _ensure_local_deps
+from voyageai.local.model_registry import ModelCache, get_model_config
+
+# Mapping from SDK output_dtype to sentence-transformers precision
+DTYPE_TO_PRECISION = {
+    "float32": "float32",
+    "float": "float32",
+    "int8": "int8",
+    "uint8": "uint8",
+    "binary": "binary",
+    "ubinary": "ubinary",
+}
+
+
+class SentenceTransformerBackend:
+    """Wrapper for sentence-transformers with SDK-compatible interface."""
+
+    def __init__(
+        self,
+        model_name: str,
+        device: Optional[str] = None,
+    ):
+        """Initialize the backend.
+
+        Args:
+            model_name: Name of the model (e.g., "voyage-4-nano").
+            device: Device to use ("cuda", "cpu", or None for auto-detect).
+        """
+        sentence_transformers, torch = _ensure_local_deps()
+
+        self.config = get_model_config(model_name)
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+        # Cache key includes model and device
+        cache_key = f"{model_name}:{self.device}"
+        cache = ModelCache()
+
+        def load_model():
+            return sentence_transformers.SentenceTransformer(
+                self.config.huggingface_id,
+                trust_remote_code=self.config.trust_remote_code,
+                device=self.device,
+            )
+
+        self.model = cache.get_or_load(cache_key, load_model)
+        self._tokenizer = self.model.tokenizer
+
+    def encode(
+        self,
+        texts: List[str],
+        input_type: Optional[str] = None,
+        output_dtype: Optional[str] = None,
+        output_dimension: Optional[int] = None,
+        truncation: bool = True,
+    ) -> np.ndarray:
+        """Encode texts into embeddings.
+
+        Args:
+            texts: List of texts to encode.
+            input_type: "query", "document", or None.
+            output_dtype: Output data type (float32, int8, uint8, binary, ubinary).
+            output_dimension: Dimension to truncate embeddings to (MRL support).
+            truncation: Whether to truncate texts exceeding max tokens.
+
+        Returns:
+            Numpy array of embeddings.
+        """
+        # Validate and get dimension
+        dimension = self.config.validate_dimension(output_dimension)
+
+        # Validate and map precision
+        self.config.validate_precision(output_dtype)
+        precision = DTYPE_TO_PRECISION.get(output_dtype) if output_dtype else None
+
+        # Build encode kwargs
+        encode_kwargs = {
+            "truncate_dim": dimension if dimension != self.config.default_dimension else None,
+        }
+        if precision:
+            encode_kwargs["precision"] = precision
+
+        # Route based on input_type
+        if input_type == "query":
+            # Use prompt-based encoding for queries
+            embeddings = self.model.encode(
+                texts,
+                prompt_name="query",
+                **encode_kwargs,
+            )
+        elif input_type == "document":
+            # Use prompt-based encoding for documents
+            embeddings = self.model.encode(
+                texts,
+                prompt_name="document",
+                **encode_kwargs,
+            )
+        else:
+            # Default encoding without prompts
+            embeddings = self.model.encode(
+                texts,
+                **encode_kwargs,
+            )
+
+        return embeddings
+
+    def count_tokens(self, texts: List[str]) -> int:
+        """Count total tokens across all texts.
+
+        Args:
+            texts: List of texts to count tokens for.
+
+        Returns:
+            Total token count.
+        """
+        total = 0
+        for text in texts:
+            encoded = self._tokenizer.encode(text, add_special_tokens=True)
+            total += len(encoded)
+        return total

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -1,6 +1,6 @@
 """Sentence-transformers backend for local model inference."""
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -15,6 +15,12 @@ DTYPE_TO_PRECISION = {
     "uint8": "uint8",
     "binary": "binary",
     "ubinary": "ubinary",
+}
+
+# Mapping from input_type to the prompt name used by the model
+INPUT_TYPE_TO_PROMPT = {
+    "query": "query",
+    "document": "document",
 }
 
 
@@ -42,14 +48,33 @@ class SentenceTransformerBackend:
         cache = ModelCache()
 
         def load_model():
-            return sentence_transformers.SentenceTransformer(
+            model = sentence_transformers.SentenceTransformer(
                 self.config.huggingface_id,
                 trust_remote_code=self.config.trust_remote_code,
                 device=self.device,
             )
+            # Apply max_tokens as model's max_seq_length
+            model.max_seq_length = self.config.max_tokens
+            return model
 
         self.model = cache.get_or_load(cache_key, load_model)
         self._tokenizer = self.model.tokenizer
+
+    def _get_prompt_for_input_type(self, input_type: Optional[str]) -> Optional[str]:
+        """Get the instruction prompt for the given input type.
+
+        Args:
+            input_type: "query", "document", or None.
+
+        Returns:
+            The prompt string, or None if no prompt applies.
+        """
+        if input_type is None:
+            return None
+        prompt_name = INPUT_TYPE_TO_PROMPT.get(input_type)
+        if prompt_name and prompt_name in self.model.prompts:
+            return self.model.prompts[prompt_name]
+        return None
 
     def encode(
         self,
@@ -58,25 +83,26 @@ class SentenceTransformerBackend:
         output_dtype: Optional[str] = None,
         output_dimension: Optional[int] = None,
         truncation: bool = True,
-    ) -> np.ndarray:
+    ) -> Tuple[np.ndarray, int]:
         """Encode texts into embeddings.
 
         Args:
             texts: List of texts to encode.
             input_type: "query", "document", or None.
-            output_dtype: Output data type (float32, int8, uint8, binary, ubinary).
+            output_dtype: Output data type (float32, float, int8, uint8, binary, ubinary).
             output_dimension: Dimension to truncate embeddings to (MRL support).
             truncation: Whether to truncate texts exceeding max tokens.
 
         Returns:
-            Numpy array of embeddings.
+            Tuple of (numpy array of embeddings, total token count).
         """
         # Validate and get dimension
         dimension = self.config.validate_dimension(output_dimension)
 
-        # Validate and map precision
-        self.config.validate_precision(output_dtype)
-        precision = DTYPE_TO_PRECISION.get(output_dtype) if output_dtype else None
+        # Validate and map precision — use returned value directly
+        precision = self.config.validate_precision(output_dtype)
+        if precision:
+            precision = DTYPE_TO_PRECISION[precision]
 
         # Build encode kwargs
         encode_kwargs = {}
@@ -85,7 +111,13 @@ class SentenceTransformerBackend:
         if precision:
             encode_kwargs["precision"] = precision
 
-        # Route based on input_type
+        # Wire truncation through to the model via processing_kwargs
+        if not truncation:
+            encode_kwargs["processing_kwargs"] = {
+                "text": {"truncation": False},
+            }
+
+        # Route based on input_type using prompt_name
         if input_type == "query":
             embeddings = self.model.encode_query(texts, **encode_kwargs)
         elif input_type == "document":
@@ -93,19 +125,37 @@ class SentenceTransformerBackend:
         else:
             embeddings = self.model.encode(texts, **encode_kwargs)
 
-        return embeddings
+        # Count tokens accounting for instruction prefix
+        total_tokens = self._count_tokens_with_prefix(texts, input_type)
 
-    def count_tokens(self, texts: List[str]) -> int:
-        """Count total tokens across all texts.
+        return embeddings, total_tokens
+
+    def _count_tokens_with_prefix(self, texts: List[str], input_type: Optional[str] = None) -> int:
+        """Count total tokens across all texts, including instruction prefix.
 
         Args:
             texts: List of texts to count tokens for.
+            input_type: "query", "document", or None.
 
         Returns:
             Total token count.
         """
+        prompt = self._get_prompt_for_input_type(input_type)
         total = 0
         for text in texts:
-            encoded = self._tokenizer.encode(text, add_special_tokens=True)
+            full_text = f"{prompt}{text}" if prompt else text
+            encoded = self._tokenizer.encode(full_text, add_special_tokens=True)
             total += len(encoded)
         return total
+
+    def count_tokens(self, texts: List[str], input_type: Optional[str] = None) -> int:
+        """Count total tokens across all texts.
+
+        Args:
+            texts: List of texts to count tokens for.
+            input_type: "query", "document", or None.
+
+        Returns:
+            Total token count.
+        """
+        return self._count_tokens_with_prefix(texts, input_type)

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -70,6 +70,8 @@ class SentenceTransformerBackend:
 
         self.model = cache.get_or_load(cache_key, load_model)
         self._tokenizer = self.model.tokenizer
+        # Serializes forward passes on this shared cached model (see encode()).
+        self._inference_lock = cache.get_inference_lock(cache_key)
 
     def _get_prompt_for_input_type(self, input_type: Optional[str]) -> Optional[str]:
         """Get the instruction prompt for the given input type.
@@ -156,34 +158,56 @@ class SentenceTransformerBackend:
         if precision:
             encode_kwargs["precision"] = precision
 
-        # Wire truncation through to the model via processing_kwargs
+        # Wire truncation through to the model. When truncation is disabled the
+        # hosted API rejects input exceeding the context length (rather than
+        # silently degrading); validate length up front and raise the same
+        # InvalidRequestError instead of feeding an over-length sequence to the
+        # model (which would crash deep inside it or degrade silently).
         if not truncation:
-            encode_kwargs["processing_kwargs"] = {
-                "text": {"truncation": False},
-            }
+            prompt = self._get_prompt_for_input_type(input_type)
+            for text in texts:
+                full_text = f"{prompt}{text}" if prompt else text
+                n = len(self._tokenizer.encode(full_text, add_special_tokens=True))
+                if n > self.config.max_tokens:
+                    raise InvalidRequestError(
+                        f"Input exceeds the {self.config.max_tokens}-token context length "
+                        "and truncation is disabled."
+                    )
+            encode_kwargs["processing_kwargs"] = {"text": {"truncation": False}}
 
-        # Route based on input_type using prompt_name
-        if input_type == "query":
-            embeddings = self.model.encode_query(texts, **encode_kwargs)
-        elif input_type == "document":
-            embeddings = self.model.encode_document(texts, **encode_kwargs)
-        else:
-            embeddings = self.model.encode(texts, **encode_kwargs)
+        # Route based on input_type using prompt_name. Serialize the forward
+        # pass: SentenceTransformer.encode* isn't contractually thread-safe, and
+        # the async path dispatches concurrent embeds onto worker threads that
+        # share this one cached model.
+        with self._inference_lock:
+            if input_type == "query":
+                embeddings = self.model.encode_query(texts, **encode_kwargs)
+            elif input_type == "document":
+                embeddings = self.model.encode_document(texts, **encode_kwargs)
+            else:
+                embeddings = self.model.encode(texts, **encode_kwargs)
 
-        # Count tokens accounting for instruction prefix
-        total_tokens = self.count_tokens(texts, input_type)
+        # Count tokens accounting for instruction prefix (and truncation cap)
+        total_tokens = self.count_tokens(texts, input_type, truncation)
 
         return embeddings, total_tokens
 
-    def count_tokens(self, texts: List[str], input_type: Optional[str] = None) -> int:
+    def count_tokens(
+        self, texts: List[str], input_type: Optional[str] = None, truncation: bool = True
+    ) -> int:
         """Count total tokens across all texts, including the instruction prefix.
 
         The model prepends an instruction prompt for query/document inputs and
         tokenizes it too, so the prefix is counted to match server-side usage.
+        When ``truncation`` is enabled the model only processes the first
+        ``max_tokens`` tokens of an over-length input, so each text's count is
+        capped there — reporting the *processed* token count, as the API does,
+        rather than the full pre-truncation length.
 
         Args:
             texts: List of texts to count tokens for.
             input_type: "query", "document", or None.
+            truncation: Whether over-length inputs are truncated to max_tokens.
 
         Returns:
             Total token count.
@@ -192,6 +216,6 @@ class SentenceTransformerBackend:
         total = 0
         for text in texts:
             full_text = f"{prompt}{text}" if prompt else text
-            encoded = self._tokenizer.encode(full_text, add_special_tokens=True)
-            total += len(encoded)
+            n = len(self._tokenizer.encode(full_text, add_special_tokens=True))
+            total += min(n, self.config.max_tokens) if truncation else n
         return total

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -144,14 +144,15 @@ class SentenceTransformerBackend:
         if precision:
             precision = DTYPE_TO_PRECISION[precision]
 
-        # Build encode kwargs
-        encode_kwargs = {}
+        # Build encode kwargs. Always normalize: the API returns unit-norm
+        # embeddings at every dimension, and truncating a unit-normalized vector
+        # (Matryoshka / MRL) breaks unit norm, so truncated and full-dim outputs
+        # must both be re-normalized. Setting this unconditionally (rather than
+        # only on the truncated branch) makes full-dim norm an explicit
+        # guarantee instead of relying on the model self-normalizing.
+        encode_kwargs = {"normalize_embeddings": True}
         if dimension != self.config.default_dimension:
-            # Truncating an already unit-normalized vector (Matryoshka / MRL)
-            # breaks unit norm, so re-normalize to match the API, which returns
-            # unit-norm embeddings at every dimension.
             encode_kwargs["truncate_dim"] = dimension
-            encode_kwargs["normalize_embeddings"] = True
         if precision:
             encode_kwargs["precision"] = precision
 
@@ -170,12 +171,15 @@ class SentenceTransformerBackend:
             embeddings = self.model.encode(texts, **encode_kwargs)
 
         # Count tokens accounting for instruction prefix
-        total_tokens = self._count_tokens_with_prefix(texts, input_type)
+        total_tokens = self.count_tokens(texts, input_type)
 
         return embeddings, total_tokens
 
-    def _count_tokens_with_prefix(self, texts: List[str], input_type: Optional[str] = None) -> int:
-        """Count total tokens across all texts, including instruction prefix.
+    def count_tokens(self, texts: List[str], input_type: Optional[str] = None) -> int:
+        """Count total tokens across all texts, including the instruction prefix.
+
+        The model prepends an instruction prompt for query/document inputs and
+        tokenizes it too, so the prefix is counted to match server-side usage.
 
         Args:
             texts: List of texts to count tokens for.
@@ -191,15 +195,3 @@ class SentenceTransformerBackend:
             encoded = self._tokenizer.encode(full_text, add_special_tokens=True)
             total += len(encoded)
         return total
-
-    def count_tokens(self, texts: List[str], input_type: Optional[str] = None) -> int:
-        """Count total tokens across all texts.
-
-        Args:
-            texts: List of texts to count tokens for.
-            input_type: "query", "document", or None.
-
-        Returns:
-            Total token count.
-        """
-        return self._count_tokens_with_prefix(texts, input_type)

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -179,27 +179,30 @@ class SentenceTransformerBackend:
         if precision:
             encode_kwargs["precision"] = precision
 
-        # Tokenize each input once and reuse the lengths for both the truncation
-        # check and the reported token count (see _token_lengths).
-        token_lengths = self._token_lengths(texts, input_type)
-
-        # When truncation is disabled the hosted API rejects input exceeding the
-        # context length (rather than silently degrading); raise the same
-        # InvalidRequestError instead of feeding an over-length sequence to the
-        # model (which would crash deep inside it or degrade silently).
-        if not truncation:
-            if any(n > self.config.max_tokens for n in token_lengths):
-                raise InvalidRequestError(
-                    f"Input exceeds the {self.config.max_tokens}-token context length "
-                    "and truncation is disabled."
-                )
-            encode_kwargs["processing_kwargs"] = {"text": {"truncation": False}}
-
-        # Route based on input_type using prompt_name. Serialize the forward
-        # pass: SentenceTransformer.encode* isn't contractually thread-safe, and
-        # the async path dispatches concurrent embeds onto worker threads that
-        # share this one cached model.
+        # Serialize ALL access to the shared cached model — both tokenization and
+        # the forward pass. self.model.tokenizer is a Rust-backed HF fast
+        # tokenizer shared process-wide via ModelCache; two async embeds
+        # tokenizing at the same time raise "RuntimeError: Already borrowed".
+        # (An earlier version locked only the forward pass, which just moved the
+        # race onto our own _token_lengths tokenizer call.)
         with self._inference_lock:
+            # Tokenize each input once; reused for the truncation check and the
+            # reported token count (see _token_lengths).
+            token_lengths = self._token_lengths(texts, input_type)
+
+            # When truncation is disabled the hosted API rejects input exceeding
+            # the context length (rather than silently degrading); raise the same
+            # InvalidRequestError instead of feeding an over-length sequence to
+            # the model (which would crash deep inside it or degrade silently).
+            # Raising inside the with-block is fine — the lock releases on except.
+            if not truncation:
+                if any(n > self.config.max_tokens for n in token_lengths):
+                    raise InvalidRequestError(
+                        f"Input exceeds the {self.config.max_tokens}-token context length "
+                        "and truncation is disabled."
+                    )
+                encode_kwargs["processing_kwargs"] = {"text": {"truncation": False}}
+
             if input_type == "query":
                 embeddings = self.model.encode_query(texts, **encode_kwargs)
             elif input_type == "document":
@@ -236,4 +239,9 @@ class SentenceTransformerBackend:
             Total token count.
         """
         cap = self.config.max_tokens
-        return sum(min(n, cap) if truncation else n for n in self._token_lengths(texts, input_type))
+        # Lock: self.model.tokenizer is a Rust-backed HF fast tokenizer shared
+        # process-wide, so a concurrent caller tokenizing at the same time would
+        # raise "RuntimeError: Already borrowed".
+        with self._inference_lock:
+            lengths = self._token_lengths(texts, input_type)
+        return sum(min(n, cap) if truncation else n for n in lengths)

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -76,6 +76,12 @@ class SentenceTransformerBackend:
     def _get_prompt_for_input_type(self, input_type: Optional[str]) -> Optional[str]:
         """Get the instruction prompt for the given input type.
 
+        Reads the model's own ``prompts`` registry — the same source
+        ``encode_query``/``encode_document`` draw from — so the prefix counted by
+        ``count_tokens`` always matches the one the model actually prepends. If
+        the model has no entry for the input type, both this and the model apply
+        no prefix, so the counts stay consistent either way.
+
         Args:
             input_type: "query", "document", or None.
 
@@ -88,6 +94,21 @@ class SentenceTransformerBackend:
         if prompt_name and prompt_name in self.model.prompts:
             return self.model.prompts[prompt_name]
         return None
+
+    def _token_lengths(self, texts: List[str], input_type: Optional[str]) -> List[int]:
+        """Token count per text, including the instruction prefix.
+
+        Tokenizes each input once; callers reuse the result for both the
+        truncation check and the reported token count so the inputs aren't
+        tokenized more than once on our side (the model still re-tokenizes
+        internally during encode — that pass is unavoidable).
+        """
+        prompt = self._get_prompt_for_input_type(input_type)
+        total = []
+        for text in texts:
+            full_text = f"{prompt}{text}" if prompt else text
+            total.append(len(self._tokenizer.encode(full_text, add_special_tokens=True)))
+        return total
 
     def encode(
         self,
@@ -158,21 +179,20 @@ class SentenceTransformerBackend:
         if precision:
             encode_kwargs["precision"] = precision
 
-        # Wire truncation through to the model. When truncation is disabled the
-        # hosted API rejects input exceeding the context length (rather than
-        # silently degrading); validate length up front and raise the same
+        # Tokenize each input once and reuse the lengths for both the truncation
+        # check and the reported token count (see _token_lengths).
+        token_lengths = self._token_lengths(texts, input_type)
+
+        # When truncation is disabled the hosted API rejects input exceeding the
+        # context length (rather than silently degrading); raise the same
         # InvalidRequestError instead of feeding an over-length sequence to the
         # model (which would crash deep inside it or degrade silently).
         if not truncation:
-            prompt = self._get_prompt_for_input_type(input_type)
-            for text in texts:
-                full_text = f"{prompt}{text}" if prompt else text
-                n = len(self._tokenizer.encode(full_text, add_special_tokens=True))
-                if n > self.config.max_tokens:
-                    raise InvalidRequestError(
-                        f"Input exceeds the {self.config.max_tokens}-token context length "
-                        "and truncation is disabled."
-                    )
+            if any(n > self.config.max_tokens for n in token_lengths):
+                raise InvalidRequestError(
+                    f"Input exceeds the {self.config.max_tokens}-token context length "
+                    "and truncation is disabled."
+                )
             encode_kwargs["processing_kwargs"] = {"text": {"truncation": False}}
 
         # Route based on input_type using prompt_name. Serialize the forward
@@ -187,8 +207,11 @@ class SentenceTransformerBackend:
             else:
                 embeddings = self.model.encode(texts, **encode_kwargs)
 
-        # Count tokens accounting for instruction prefix (and truncation cap)
-        total_tokens = self.count_tokens(texts, input_type, truncation)
+        # With truncation on, the model only processes the first max_tokens tokens
+        # of an over-length input, so cap each count to report the processed total
+        # (matching the API) rather than the full pre-truncation length.
+        cap = self.config.max_tokens
+        total_tokens = sum(min(n, cap) if truncation else n for n in token_lengths)
 
         return embeddings, total_tokens
 
@@ -212,10 +235,5 @@ class SentenceTransformerBackend:
         Returns:
             Total token count.
         """
-        prompt = self._get_prompt_for_input_type(input_type)
-        total = 0
-        for text in texts:
-            full_text = f"{prompt}{text}" if prompt else text
-            n = len(self._tokenizer.encode(full_text, add_special_tokens=True))
-            total += min(n, self.config.max_tokens) if truncation else n
-        return total
+        cap = self.config.max_tokens
+        return sum(min(n, cap) if truncation else n for n in self._token_lengths(texts, input_type))

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -7,15 +7,25 @@ import numpy as np
 from voyageai.local import _ensure_local_deps
 from voyageai.local.model_registry import ModelCache, get_model_config
 
-# Mapping from SDK output_dtype to sentence-transformers precision
+# Mapping from SDK output_dtype to sentence-transformers precision.
+#
+# int8/uint8 are intentionally absent: matching the hosted API requires fixed
+# calibration ranges, which we don't have for local models. Without them
+# sentence-transformers derives the quantization range from the current batch,
+# yielding non-deterministic, API-incompatible vectors — so int8/uint8 are
+# rejected up front in ``encode`` rather than returning silently-wrong output.
 DTYPE_TO_PRECISION = {
     "float32": "float32",
     "float": "float32",
-    "int8": "int8",
-    "uint8": "uint8",
     "binary": "binary",
     "ubinary": "ubinary",
 }
+
+# Output dtypes that require fixed calibration ranges we don't yet ship locally.
+_UNSUPPORTED_QUANTIZED_DTYPES = ("int8", "uint8")
+
+# Valid input_type values (None means no instruction prompt).
+_VALID_INPUT_TYPES = (None, "query", "document")
 
 # Mapping from input_type to the prompt name used by the model
 INPUT_TYPE_TO_PROMPT = {
@@ -89,13 +99,35 @@ class SentenceTransformerBackend:
         Args:
             texts: List of texts to encode.
             input_type: "query", "document", or None.
-            output_dtype: Output data type (float32, float, int8, uint8, binary, ubinary).
+            output_dtype: Output data type (float32, float, binary, ubinary).
             output_dimension: Dimension to truncate embeddings to (MRL support).
             truncation: Whether to truncate texts exceeding max tokens.
 
         Returns:
             Tuple of (numpy array of embeddings, total token count).
+
+        Raises:
+            ValueError: If input_type is not one of None/"query"/"document".
+            NotImplementedError: If output_dtype is int8/uint8 (see
+                DTYPE_TO_PRECISION for why these are unsupported locally).
         """
+        # Reject invalid input_type up front. The hosted API raises for unknown
+        # values; without this the unknown value would silently fall through to
+        # the no-prompt branch and degrade embedding quality.
+        if input_type not in _VALID_INPUT_TYPES:
+            raise ValueError(
+                f"Invalid input_type {input_type!r}. " f"Use 'query', 'document', or None."
+            )
+
+        # int8/uint8 need fixed calibration ranges to match the API; reject
+        # rather than return non-deterministic, incomparable vectors.
+        if output_dtype in _UNSUPPORTED_QUANTIZED_DTYPES:
+            raise NotImplementedError(
+                f"output_dtype={output_dtype!r} is not supported for local models. "
+                "int8/uint8 quantization requires fixed calibration ranges to match "
+                "the hosted API; use 'float'/'float32' or 'binary'/'ubinary'."
+            )
+
         # Validate and get dimension
         dimension = self.config.validate_dimension(output_dimension)
 
@@ -107,7 +139,11 @@ class SentenceTransformerBackend:
         # Build encode kwargs
         encode_kwargs = {}
         if dimension != self.config.default_dimension:
+            # Truncating an already unit-normalized vector (Matryoshka / MRL)
+            # breaks unit norm, so re-normalize to match the API, which returns
+            # unit-norm embeddings at every dimension.
             encode_kwargs["truncate_dim"] = dimension
+            encode_kwargs["normalize_embeddings"] = True
         if precision:
             encode_kwargs["precision"] = precision
 

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 
+from voyageai.error import InvalidRequestError
 from voyageai.local import _ensure_local_deps
 from voyageai.local.model_registry import ModelCache, get_model_config
 
@@ -107,20 +108,27 @@ class SentenceTransformerBackend:
             Tuple of (numpy array of embeddings, total token count).
 
         Raises:
-            ValueError: If input_type is not one of None/"query"/"document".
-            NotImplementedError: If output_dtype is int8/uint8 (see
-                DTYPE_TO_PRECISION for why these are unsupported locally).
+            InvalidRequestError: If input_type/output_dtype/output_dimension is
+                invalid. Mirrors the hosted API's validation so callers can
+                catch the same exception on both paths.
+            NotImplementedError: If output_dtype is int8/uint8. These are valid
+                against the hosted API but unsupported locally because they
+                require fixed calibration ranges we don't ship yet — a genuine
+                capability gap rather than an invalid request (see
+                DTYPE_TO_PRECISION).
         """
         # Reject invalid input_type up front. The hosted API raises for unknown
         # values; without this the unknown value would silently fall through to
         # the no-prompt branch and degrade embedding quality.
         if input_type not in _VALID_INPUT_TYPES:
-            raise ValueError(
-                f"Invalid input_type {input_type!r}. " f"Use 'query', 'document', or None."
+            raise InvalidRequestError(
+                f"Invalid input_type {input_type!r}. Use 'query', 'document', or None."
             )
 
         # int8/uint8 need fixed calibration ranges to match the API; reject
-        # rather than return non-deterministic, incomparable vectors.
+        # rather than return non-deterministic, incomparable vectors. This is a
+        # local capability gap (the API accepts them), so NotImplementedError —
+        # not InvalidRequestError — is the honest signal.
         if output_dtype in _UNSUPPORTED_QUANTIZED_DTYPES:
             raise NotImplementedError(
                 f"output_dtype={output_dtype!r} is not supported for local models. "

--- a/voyageai/local/sentence_transformer_backend.py
+++ b/voyageai/local/sentence_transformer_backend.py
@@ -79,33 +79,19 @@ class SentenceTransformerBackend:
         precision = DTYPE_TO_PRECISION.get(output_dtype) if output_dtype else None
 
         # Build encode kwargs
-        encode_kwargs = {
-            "truncate_dim": dimension if dimension != self.config.default_dimension else None,
-        }
+        encode_kwargs = {}
+        if dimension != self.config.default_dimension:
+            encode_kwargs["truncate_dim"] = dimension
         if precision:
             encode_kwargs["precision"] = precision
 
         # Route based on input_type
         if input_type == "query":
-            # Use prompt-based encoding for queries
-            embeddings = self.model.encode(
-                texts,
-                prompt_name="query",
-                **encode_kwargs,
-            )
+            embeddings = self.model.encode_query(texts, **encode_kwargs)
         elif input_type == "document":
-            # Use prompt-based encoding for documents
-            embeddings = self.model.encode(
-                texts,
-                prompt_name="document",
-                **encode_kwargs,
-            )
+            embeddings = self.model.encode_document(texts, **encode_kwargs)
         else:
-            # Default encoding without prompts
-            embeddings = self.model.encode(
-                texts,
-                **encode_kwargs,
-            )
+            embeddings = self.model.encode(texts, **encode_kwargs)
 
         return embeddings
 


### PR DESCRIPTION
Seamless integration of local model(s)

Reopened from #49 — moved to upstream branch for CI secret access.

## Tracked follow-ups (intentionally out of scope for this PR)

- #65 — Local models: batched encode instead of the serial inference lock (throughput). The current per-model lock is a correct, documented defensive fix; real parallelism needs request coalescing, which is a separate feature.
- #66 — Local models: expose a `trust_remote_code` opt-out. Deferred because the only supported local model (`voyage-4-nano`) requires it; revisit when a second/community model with a different trust boundary is added.
