### PR TITLE
Add license field to pyproject.toml and bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.poetry]
 name = "voyageai"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 authors = ["Yujie Qian <yujieq@voyageai.com>"]
+license = {file = "LICENSE"}
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "voyageai"
 version = "0.4.1"
 description = ""
 authors = ["Yujie Qian <yujieq@voyageai.com>"]
-license = {file = "LICENSE"}
+license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary
- Explicitly declare the MIT license in `pyproject.toml` metadata (`license = "MIT"`)
- Bump version from 0.4.0 to 0.4.1

## Notes
- Uses the Poetry string format (`license = "MIT"`) rather than PEP 621 table format (`{file = "LICENSE"}`) for compatibility with the `[tool.poetry]` section