### PR TITLE
fix: forward input_type in async embedding helpers

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -623,9 +623,7 @@ class TestEmbeddingsUtils:
 
         mock_response = MagicMock()
         mock_response.data = [{"embedding": [0.1]}]
-        with patch(
-            "voyageai.Embedding.acreate", return_value=mock_response
-        ) as mock_acreate:
+        with patch("voyageai.Embedding.acreate", return_value=mock_response) as mock_acreate:
             await _aget_embeddings(["a"], model="voyage-3", input_type="query")
 
         assert mock_acreate.call_args.kwargs["input_type"] == "query"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -617,6 +617,19 @@ class TestEmbeddingsUtils:
             result = await _aget_embeddings(["a", "b"], model="voyage-3")
             assert result == [[0.1], [0.2]]
 
+    @pytest.mark.asyncio
+    async def test_aget_embeddings_forwards_input_type(self):
+        from voyageai.embeddings_utils import _aget_embeddings
+
+        mock_response = MagicMock()
+        mock_response.data = [{"embedding": [0.1]}]
+        with patch(
+            "voyageai.Embedding.acreate", return_value=mock_response
+        ) as mock_acreate:
+            await _aget_embeddings(["a"], model="voyage-3", input_type="query")
+
+        assert mock_acreate.call_args.kwargs["input_type"] == "query"
+
     def test_get_embedding_deprecation_warning(self):
         from voyageai.embeddings_utils import get_embedding
 

--- a/voyageai/embeddings_utils.py
+++ b/voyageai/embeddings_utils.py
@@ -67,7 +67,9 @@ async def _aget_embeddings(
     async with semaphore:
         async with rate_limit:
             data = (
-                await voyageai.Embedding.acreate(input=list_of_text, model=model, input_type=input_type, **kwargs)
+                await voyageai.Embedding.acreate(
+                    input=list_of_text, model=model, input_type=input_type, **kwargs
+                )
             ).data
 
     return [d["embedding"] for d in data]

--- a/voyageai/embeddings_utils.py
+++ b/voyageai/embeddings_utils.py
@@ -67,7 +67,7 @@ async def _aget_embeddings(
     async with semaphore:
         async with rate_limit:
             data = (
-                await voyageai.Embedding.acreate(input=list_of_text, model=model, **kwargs)
+                await voyageai.Embedding.acreate(input=list_of_text, model=model, input_type=input_type, **kwargs)
             ).data
 
     return [d["embedding"] for d in data]


### PR DESCRIPTION
## What

The async embedding helpers validate `input_type` but then drop it. In `voyageai/embeddings_utils.py`:

- **Sync** `_get_embeddings` forwards it: `Embedding.create(input=..., model=..., input_type=input_type, **kwargs)`.
- **Async** `_aget_embeddings` validates it (`_check_input_type(input_type)`) but calls `Embedding.acreate(input=..., model=..., **kwargs)` — **`input_type` is a named parameter, not part of `**kwargs`, so it never reaches the API.**

Both public async functions (`aget_embedding`, `aget_embeddings`) route through `_aget_embeddings`, so:

```python
await aget_embedding(text, model="voyage-3", input_type="query")
```

computes the embedding with **no input-type prefix**, which degrades retrieval quality — a silent correctness bug and a sync/async divergence.

## Fix

Forward `input_type` in the async call, mirroring the sync path:

```python
await voyageai.Embedding.acreate(
    input=list_of_text, model=model, input_type=input_type, **kwargs
)
```

## Testing

Added `test_aget_embeddings_forwards_input_type` to `TestEmbeddingsUtils` (mirrors the existing `test_aget_embeddings_internal` mocked pattern) asserting `acreate` is called with `input_type="query"`. Fully offline (mocks `acreate`, no API key). It fails on `main` and passes with the fix.